### PR TITLE
Only run geerlingguy.repo-epel role on RedHat distros

### DIFF
--- a/stratum0.yml
+++ b/stratum0.yml
@@ -5,5 +5,6 @@
   vars:
     cvmfs_repositories: "{{ eessi_cvmfs_repositories + [eessi_cvmfs_config_repo.repository] }}"
   roles:
-    - geerlingguy.repo-epel
+    - role: geerlingguy.repo-epel
+      when: ansible_facts['os_family'] == 'RedHat'
     - cvmfs

--- a/stratum1.yml
+++ b/stratum1.yml
@@ -8,5 +8,6 @@
     cvmfs_keys: "{{ eessi_cvmfs_keys + [eessi_cvmfs_config_repo.key] }}"
     cvmfs_squid_conf_src: eessi_stratum1_squid.conf.j2
   roles:
-    - geerlingguy.repo-epel
+    - role: geerlingguy.repo-epel
+      when: ansible_facts['os_family'] == 'RedHat'
     - cvmfs


### PR DESCRIPTION
Thought that the role itself would do nothing on non-Redhat distros, but @JvD007 found that it does on for instance Ubuntu. This has been fixed by adding a conditional to the playbooks.