### PR TITLE
Fix error in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ sudo cvmfs_config chksetup
 
 In case of unclear issues, you can enable the debug mode and log to a file by setting the following environment variable:
 ```
-CVMFS_DEBUGFILE=/some/path/to/cvmfs.log
+CVMFS_DEBUGLOG=/some/path/to/cvmfs.log
 ```
 
 ### Proxy / Stratum 1


### PR DESCRIPTION
Our README currently says that you can set CVMFS_DEBUGFILE to get debug messages, as explained here:
https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#debug-logs

But this does not seem to work, and some other page in another CVMFS documentation says that it should be CVMFS_DEBUGLOG, which does seem to work.