### PR TITLE
Fix CVMFS Youtube video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ The EESSI project uses the CernVM File System (CVMFS) for distributing its softw
 - http://cernvm.cern.ch/portal/filesystem
 - https://cvmfs.readthedocs.io
 
-The following introductory video on Youtube gives a quite good overview of CVMFS as well:
-https://www.youtube.com/playlist?list=FLqCLabkRddpbHj4wYNFYjAA
+The following introductory video on Youtube gives a quite good overview of CVMFS as well: https://www.youtube.com/watch?v=MyYx-xaL36k
 
 ## CVMFS infrastructure
 


### PR DESCRIPTION
The documentation points to a favorites list of videos.
From the list, I could only find this (video|https://www.youtube.com/watch?v=MyYx-xaL36k) that talks about CVMFS.
I am updating the link from the favorites list of videos to the actual video itself.