### PR TITLE
Have the packages create a local defaults

### DIFF
--- a/prepare-client-packages.yml
+++ b/prepare-client-packages.yml
@@ -43,3 +43,11 @@
           CVMFS_DEFAULT_DOMAIN="{{ eessi_cvmfs_config_repo.domain }}"
         dest: "{{ package_source_dir }}/etc/cvmfs/default.d/80-eessi-cvmfs.conf"
         mode: 0644
+
+    - name: Populate EESSI CVMFS local configuration file with some semi-sane defaults
+      copy:
+        content: |
+          CVMFS_HTTP_PROXY=DIRECT
+          CVMFS_QUOTA_LIMIT=5000
+        dest: "{{ package_source_dir }}/etc/cvmfs/default.local
+        mode: 0644


### PR DESCRIPTION
  - The defaults are safe and boring.
  - There should be a test to see if there is a proxy available.
    Maybe we can suggest eessi-proxy.domain.tld and add that if
    found. Hm.