### PR TITLE
Version bump of Ansible roles

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@
 roles:
 
   - name: galaxyproject.cvmfs
-    version: 0.2.13
+    version: 0.2.14
 
   - name: geerlingguy.repo-epel
-    version: 1.3.0
+    version: 3.0.0


### PR DESCRIPTION
Version bump of `ansible-cvmfs` (which has a nice fix/improvement for the CVMFS garbage collection) and `repo-epel`.