### PR TITLE
Set auto tag timespan to 30 days

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -69,8 +69,8 @@ eessi_cvmfs_repositories:
     key_dir: /etc/cvmfs/keys/eessi-hpc.org
     server_options:
       - CVMFS_AUTO_GC=false
+      - CVMFS_AUTO_TAG_TIMESPAN="30 days ago"
       - CVMFS_GARBAGE_COLLECTION=true
-      - CVMFS_AUTO_GC=false
     client_options:
       - CVMFS_NFILES=4096
 


### PR DESCRIPTION
Closes #61. The garbage collection itself was fixed in https://github.com/galaxyproject/ansible-cvmfs/pull/31, and this is now being used via #71.