### PR TITLE
Add version to filenames of tarball configuration packages

### DIFF
--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -61,7 +61,7 @@ jobs:
         uses: bpicode/github-action-fpm@master
         with:
           fpm_args: "etc"
-          fpm_opts: "--debug -n cvmfs-config-eessi -v ${{ steps.get_version.outputs.version }} -t tar -a all -s dir -C ./package --description 'CVMFS configuration package for EESSI.'"
+          fpm_opts: "--debug -n cvmfs-config-eessi-${{ steps.get_version.outputs.version }} -t tar -a all -s dir -C ./package --description 'CVMFS configuration package for EESSI.'"
 
       - name: Find filenames of generated packages
         id: find_filenames


### PR DESCRIPTION
The `fpm` tool does add the version number to the filename of deb/rpm packages, but not to tarballs, see:
https://github.com/EESSI/filesystem-layer/releases/tag/v0.3.0

This small modification does that manually.