### PR TITLE
Quick fix for Docker Hub images

### DIFF
--- a/containers/Dockerfile.EESSI-client-pilot-centos7-aarch64
+++ b/containers/Dockerfile.EESSI-client-pilot-centos7-aarch64
@@ -3,11 +3,11 @@ FROM docker.io/arm64v8/centos:7
 RUN yum install -y http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-release-latest.noarch.rpm \
  && yum install -y cvmfs cvmfs-fuse3 --nogpgcheck \
  && yum install -y cvmfs-config-default sudo vim openssh-clients \
- && yum install -y https://github.com/EESSI/filesystem-layer/releases/download/v0.2.3/cvmfs-config-eessi-0.2.3-1.noarch.rpm
+ && yum install -y https://github.com/EESSI/filesystem-layer/releases/download/v0.3.1/cvmfs-config-eessi-0.3.1-1.noarch.rpm
 
 RUN echo 'CVMFS_QUOTA_LIMIT=10000' > /etc/cvmfs/default.local \
-  && echo 'CVMFS_HTTP_PROXY="DIRECT"' >> /etc/cvmfs/default.local
+  && echo 'CVMFS_CLIENT_PROFILE="single"' >> /etc/cvmfs/default.local
 
-RUN mkdir -p /cvmfs/{cvmfs-config.eessi-hpc.org,pilot.eessi-hpc.org}
+RUN mkdir -p /cvmfs/pilot.eessi-hpc.org
 
 RUN useradd -ms /bin/bash eessi

--- a/containers/Dockerfile.EESSI-client-pilot-centos7-ppc64le
+++ b/containers/Dockerfile.EESSI-client-pilot-centos7-ppc64le
@@ -1,6 +1,6 @@
 FROM docker.io/ppc64le/centos:7
-ARG cvmfsversion=2.8.0
-ARG cvmfsconfig=https://github.com/EESSI/filesystem-layer/releases/download/v0.2.3/cvmfs-config-eessi-0.2.3-1.noarch.rpm
+ARG cvmfsversion=2.8.1
+ARG cvmfsconfig=https://github.com/EESSI/filesystem-layer/releases/download/v0.3.1/cvmfs-config-eessi-0.3.1-1.noarch.rpm
 
 RUN yum install -y sudo vim openssh-clients cmake wget make unzip patch valgrind bzip2
 
@@ -24,8 +24,8 @@ RUN yum install -y ${cvmfsconfig}
 RUN yum remove -y fuse && yum install -y fuse3
 
 RUN echo 'CVMFS_QUOTA_LIMIT=10000' > /etc/cvmfs/default.local \
-  && echo 'CVMFS_HTTP_PROXY="DIRECT"' >> /etc/cvmfs/default.local
+  && echo 'CVMFS_CLIENT_PROFILE="single"' >> /etc/cvmfs/default.local
 
-RUN mkdir -p /cvmfs/{cvmfs-config.eessi-hpc.org,pilot.eessi-hpc.org}
+RUN mkdir -p /cvmfs/pilot.eessi-hpc.org
 
 RUN useradd -ms /bin/bash eessi

--- a/containers/Dockerfile.EESSI-client-pilot-centos7-x86_64
+++ b/containers/Dockerfile.EESSI-client-pilot-centos7-x86_64
@@ -2,11 +2,11 @@ FROM docker.io/library/centos:7
 
 RUN yum install -y http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-release-latest.noarch.rpm \
  && yum install -y cvmfs cvmfs-config-default cvmfs-fuse3 sudo vim openssh-clients \
- && yum install -y https://github.com/EESSI/filesystem-layer/releases/download/v0.2.3/cvmfs-config-eessi-0.2.3-1.noarch.rpm
+ && yum install -y https://github.com/EESSI/filesystem-layer/releases/download/v0.3.1/cvmfs-config-eessi-0.3.1-1.noarch.rpm
 
 RUN echo 'CVMFS_QUOTA_LIMIT=10000' > /etc/cvmfs/default.local \
-  && echo 'CVMFS_HTTP_PROXY="DIRECT"' >> /etc/cvmfs/default.local
+  && echo 'CVMFS_CLIENT_PROFILE="single"' >> /etc/cvmfs/default.local
 
-RUN mkdir -p /cvmfs/{cvmfs-config.eessi-hpc.org,pilot.eessi-hpc.org}
+RUN mkdir -p /cvmfs/pilot.eessi-hpc.org
 
 RUN useradd -ms /bin/bash eessi


### PR DESCRIPTION
These still had the old config package installed, causing issues while the RUG Stratum 1 is down. I've pushed new versions of the images with the latest config package installed for `aarch64`, `ppc64le`, and `x86_64`; this PR contains the modified Dockerfiles. 