### PR TITLE
First version of tarball ingestion script

### DIFF
--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Ingest a tarball containing software, a compatibility layer,
+# or init scripts to the EESSI CVMFS repository, and generate
+# nested catalogs in a separate transaction.
+
+tar_file=$1
+repo=pilot.eessi-hpc.org
+decompress="gunzip -c"
+
+function echo_green() {
+    echo -e "\e[32m$1\e[0m"
+}
+
+function echo_red() {
+    echo -e "\e[31m$1\e[0m"
+}
+
+function error() {
+    echo_red "ERROR: $1" >&2
+    exit 1
+}
+# Check if a tarball has been specified
+if [ "$#" -ne 1 ]; then
+    error "usage: $0 <gzipped tarball>"
+fi
+
+# Check if the given tarball exists
+if [ ! -f "${tar_file}" ]; then
+    error "tar file ${tar_file} does not exist!"
+fi
+
+tar_file_basename=$(basename "${tar_file}")
+version=$(echo ${tar_file} | cut -d- -f2)
+top_level_dir=$(echo ${tar_file} | cut -d- -f3)
+tar_top_level_dir=$(tar tf "${tar_file}" | head -n 1 | cut -d/ -f1)
+
+# Check if the top level dir encoded in the filename
+# matches the top lever dir inside the tarball
+if [ "${top_level_dir}" != "${tar_top_level_dir}" ]
+then
+    error "the top level directory in the filename (${top_level_dir}) does not match the top level directory in the tar ball (${tar_top_level_dir})."
+fi
+
+# We assume that the top level dir must be compat, software, or init
+if [ "${tar_top_level_dir}" != "compat" ] && [ "${tar_top_level_dir}" != "software" ] && [ "${tar_top_level_dir}" != "init" ]
+then
+    error "the top level directory in the tar ball should be either compat, software, or init!"
+fi
+
+# Check of the EESSI version number encoded in the filename
+# is a valid, i.e. matches the format YYYY.DD
+if ! echo "${version}" | egrep -q '^20[0-9][0-9]\.(0[0-9]|1[0-2])$'
+then
+    error "${version} is not a valid EESSI version."
+fi
+
+# Ingest the tarball to the repository
+${decompress} "${tar_file}" | cvmfs_server ingest -t - -b "${version}" "${repo}" && echo_green "${tar_file} ingested to ${repo}"
+
+# Use the .cvmfsdirtab to generate nested catalogs for the ingested tarball
+cvmfs_server transaction "${repo}"
+cvmfs_server publish -m "Generate catalogs after ingesting ${tar_file_basename}" "${repo}"

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -58,8 +58,24 @@ then
 fi
 
 # Ingest the tarball to the repository
-${decompress} "${tar_file}" | cvmfs_server ingest -t - -b "${version}" "${repo}" && echo_green "${tar_file} ingested to ${repo}"
+echo "Ingesting tarball ${tar_file} to ${repo}..."
+${decompress} "${tar_file}" | cvmfs_server ingest -t - -b "${version}" "${repo}"
+ec=$?
+if [ $ec -eq 0 ]
+then
+    echo_green "${tar_file} has been ingested to ${repo}."
+else
+    error "${tar_file} could not be ingested to ${repo}."
+fi
 
 # Use the .cvmfsdirtab to generate nested catalogs for the ingested tarball
+echo "Generating the nested catalogs..."
 cvmfs_server transaction "${repo}"
 cvmfs_server publish -m "Generate catalogs after ingesting ${tar_file_basename}" "${repo}"
+ec=$?
+if [ $ec -eq 0 ]
+then
+    echo_green "Nested catalogs for ${repo} have been created!"
+else
+    echo_red "failure when creating nested catalogs for ${repo}."
+fi

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -3,6 +3,7 @@
 # Ingest a tarball containing software, a compatibility layer,
 # or init scripts to the EESSI CVMFS repository, and generate
 # nested catalogs in a separate transaction.
+# This script has to be run on a CVMFS publisher node.
 
 tar_file=$1
 repo=pilot.eessi-hpc.org

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -5,7 +5,6 @@
 # nested catalogs in a separate transaction.
 # This script has to be run on a CVMFS publisher node.
 
-tar_file=$1
 repo=pilot.eessi-hpc.org
 decompress="gunzip -c"
 
@@ -25,6 +24,8 @@ function error() {
 if [ "$#" -ne 1 ]; then
     error "usage: $0 <gzipped tarball>"
 fi
+
+tar_file="$1"
 
 # Check if the given tarball exists
 if [ ! -f "${tar_file}" ]; then


### PR DESCRIPTION
Just used this version to ingest the new compat layer tarball.

```
# ingest-tarball.sh eessi-2021.06-compat-linux-x86_64-1624347201.tar.gz 
Using auto tag 'generic-2021-06-22T09:07:09Z'
Processing changes...
...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Waiting for upload of files before committing...
Committing file catalogs...
WARNING: catalog at / has more than 200000 entries (244823). Large catalogs stress the CernVM-FS transport infrastructure. Please split it into nested catalogs or increase the limit.
Wait for all uploads to finish
Exporting repository manifest
Statistics stored at: /var/spool/cvmfs/pilot.eessi-hpc.org/stats.db
Tagging pilot.eessi-hpc.org
Flushing file system buffers
Signing new manifest
Remounting newly created repository revision
eessi-2021.06-compat-linux-x86_64-1624347201.tar.gz ingested to pilot.eessi-hpc.org
Using auto tag 'generic-2021-06-22T09:09:03Z'
Processing changes...
Waiting for upload of files before committing...
Committing file catalogs...
Note: Catalog at /2021.06/compat/linux/x86_64/var gets defragmented (85.32% free pages)... done
Note: Catalog at /2021.06/compat/linux/x86_64 gets defragmented (61.42% free pages)... done
Note: Catalog at / gets defragmented (99.91% free pages)... done
Wait for all uploads to finish
Exporting repository manifest
Statistics stored at: /var/spool/cvmfs/pilot.eessi-hpc.org/stats.db
Tagging pilot.eessi-hpc.org
Flushing file system buffers
Signing new manifest
Remounting newly created repository revision
```