### PR TITLE
Fixes for fuse-overlayfs in container images

### DIFF
--- a/containers/Dockerfile.EESSI-build-node-debian10
+++ b/containers/Dockerfile.EESSI-build-node-debian10
@@ -1,5 +1,4 @@
 ARG cvmfsversion=2.8.1
-ARG fuseoverlayfsversion=0.4.1
 
 FROM debian:10.6 AS prepare-deb
 ARG cvmfsversion
@@ -18,6 +17,7 @@ RUN dpkg -i /root/deb/cvmfs_${cvmfsversion}~1+debian10_$(dpkg --print-architectu
             /root/deb/cvmfs-fuse3_${cvmfsversion}~1+debian10_$(dpkg --print-architecture).deb \
             /root/deb/cvmfs-config-default_latest_all.deb \
             /root/deb/cvmfs-config-eessi_latest_all.deb
+RUN apt-get install -y fuse-overlayfs
 
 RUN echo 'CVMFS_QUOTA_LIMIT=10000' > /etc/cvmfs/default.local \
   && echo 'CVMFS_CLIENT_PROFILE="single"' >> /etc/cvmfs/default.local

--- a/containers/Dockerfile.EESSI-client-pilot-centos7
+++ b/containers/Dockerfile.EESSI-client-pilot-centos7
@@ -1,4 +1,6 @@
 ARG cvmfsversion=2.8.1
+# Stick to old version of fuse-overlayfs due to issues with newer versions
+# (cfr. https://github.com/containers/fuse-overlayfs/issues/232)
 ARG fuseoverlayfsversion=0.3
 
 FROM centos:7 AS prepare-rpm

--- a/containers/Dockerfile.EESSI-client-pilot-centos7
+++ b/containers/Dockerfile.EESSI-client-pilot-centos7
@@ -1,5 +1,5 @@
 ARG cvmfsversion=2.8.1
-ARG fuseoverlayfsversion=0.4.1
+ARG fuseoverlayfsversion=0.3
 
 FROM centos:7 AS prepare-rpm
 ARG cvmfsversion


### PR DESCRIPTION
Adds fuse-overlayfs to the build-node image, and switches to an older version in the client one.