### PR TITLE
PRs that change any Dockerfile should trigger the container CI

### DIFF
--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
     paths:
-      - containers/Dockerfile.EESSI-client*
+      - containers/Dockerfile.EESSI-*
       - containers/build-or-download-cvmfs-rpm.sh
 
   # also rebuild the containers for new releases of filesystem-layer:


### PR DESCRIPTION
Just noticed that the container CI didn't get run for PR #91, because it only does it when the client container Dockerfile gets changed. This should fix that, and run it for changes in any Dockerfile.