### PR TITLE
include jq in build container (required by eessi-upload-to-staging script)

### DIFF
--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   build_and_publish:
     name: Build and publish image
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       packages: write
       contents: read

--- a/containers/Dockerfile.EESSI-build-node-debian10
+++ b/containers/Dockerfile.EESSI-build-node-debian10
@@ -14,7 +14,9 @@ ARG awscliversion
 COPY --from=prepare-deb /root/deb /root/deb
 
 RUN apt-get update
-RUN apt-get install -y sudo vim openssh-client gawk autofs curl attr uuid fuse3 libfuse2 psmisc gdb uuid-dev unzip python3-pip
+RUN apt-get install -y sudo vim openssh-client gawk autofs curl attr uuid fuse3 libfuse2 psmisc gdb uuid-dev
+# python3 and jq are required for eessi-upload-to-staging script (next to awscli)
+RUN apt-get install -y python3-pip jq
 RUN dpkg -i /root/deb/cvmfs_${cvmfsversion}~1+debian10_$(dpkg --print-architecture).deb \
             /root/deb/cvmfs-fuse3_${cvmfsversion}~1+debian10_$(dpkg --print-architecture).deb \
             /root/deb/cvmfs-config-default_latest_all.deb \


### PR DESCRIPTION
fix for:

```
/usr/bin/eessi-upload-to-staging: line 34: jq: command not found
```

should have been included in #91...