### PR TITLE
Prepend ingestion base directory with "versions" directory (+ some fixes for Ansible CI workflows)

### DIFF
--- a/.github/workflows/Dockerfile-ubuntu-18.04
+++ b/.github/workflows/Dockerfile-ubuntu-18.04
@@ -3,10 +3,9 @@ FROM ubuntu:18.04
 USER root
 
 RUN apt-get update
-RUN apt-get install -y cron gpg python3-pip systemd
+RUN apt-get install -y cron gpg python3.8 systemd
 
-RUN pip3 install --upgrade pip
-RUN pip3 install 'ansible<5'
+RUN python3.8 -m pip install ansible
 
 COPY ./.github/workflows/test-playbook.sh /test-playbook.sh
 

--- a/.github/workflows/Dockerfile-ubuntu-18.04
+++ b/.github/workflows/Dockerfile-ubuntu-18.04
@@ -5,6 +5,7 @@ USER root
 RUN apt-get update
 RUN apt-get install -y cron gpg python3-pip systemd
 
+RUN pip3 install --upgrade pip
 RUN pip3 install 'ansible<5'
 
 COPY ./.github/workflows/test-playbook.sh /test-playbook.sh

--- a/.github/workflows/Dockerfile-ubuntu-18.04
+++ b/.github/workflows/Dockerfile-ubuntu-18.04
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 USER root
 
 RUN apt-get update
-RUN apt-get install -y cron gpg python3.8 systemd
+RUN apt-get install -y cron gpg python3.8 python3-pip systemd
 
 RUN python3.8 -m pip install ansible
 

--- a/.github/workflows/Dockerfile-ubuntu-18.04
+++ b/.github/workflows/Dockerfile-ubuntu-18.04
@@ -5,7 +5,7 @@ USER root
 RUN apt-get update
 RUN apt-get install -y cron gpg python3-pip systemd
 
-RUN pip3 install ansible<5
+RUN pip3 install 'ansible<5'
 
 COPY ./.github/workflows/test-playbook.sh /test-playbook.sh
 

--- a/.github/workflows/Dockerfile-ubuntu-18.04
+++ b/.github/workflows/Dockerfile-ubuntu-18.04
@@ -5,7 +5,7 @@ USER root
 RUN apt-get update
 RUN apt-get install -y cron gpg python3-pip systemd
 
-RUN pip3 install ansible
+RUN pip3 install ansible<5
 
 COPY ./.github/workflows/test-playbook.sh /test-playbook.sh
 

--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -34,7 +34,7 @@ jobs:
         run: ln -s inventory/group_vars
 
       - name: Prepare package source
-        uses: roles-ansible/check-ansible-debian-stretch-action@master
+        uses: roles-ansible/check-ansible-debian-stable-action@master
         with:
           targets: "./prepare-client-packages.yml"
           hosts: "localhost"

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -47,7 +47,7 @@ tar_top_level_dir=$(tar tf "${tar_file}" | head -n 1 | cut -d/ -f1)
 # Use the 2nd file/dir in the tarball, as the first one may be just "<version>/"
 tar_contents_type_dir=$(tar tf "${tar_file}" | head -n 2 | tail -n 1 | cut -d/ -f2)
 
-# Check of the EESSI version number encoded in the filename
+# Check if the EESSI version number encoded in the filename
 # is a valid, i.e. matches the format YYYY.DD
 if ! echo "${version}" | egrep -q '^20[0-9][0-9]\.(0[0-9]|1[0-2])$'
 then

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -48,7 +48,7 @@ tar_top_level_dir=$(tar tf "${tar_file}" | head -n 1 | cut -d/ -f1)
 tar_contents_type_dir=$(tar tf "${tar_file}" | head -n 2 | tail -n 1 | cut -d/ -f2)
 
 # Check if the EESSI version number encoded in the filename
-# is a valid, i.e. matches the format YYYY.DD
+# is valid, i.e. matches the format YYYY.DD
 if ! echo "${version}" | egrep -q '^20[0-9][0-9]\.(0[0-9]|1[0-2])$'
 then
     error "${version} is not a valid EESSI version."

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -28,6 +28,7 @@ function error() {
     echo_red "ERROR: $1" >&2
     exit 1
 }
+
 # Check if a tarball has been specified
 if [ "$#" -ne 1 ]; then
     error "usage: $0 <gzipped tarball>"
@@ -86,7 +87,7 @@ fi
 # Use the .cvmfsdirtab to generate nested catalogs for the ingested tarball
 echo "Generating the nested catalogs..."
 cvmfs_server transaction "${repo}"
-cvmfs_server publish -m "Generate catalogs after ingesting ${tar_file_basename}" "${repo}"
+cvmfs_server publish -m "Generate catalogs after ingesting ${tar_file_basename}" to "${repo}"
 ec=$?
 if [ $ec -eq 0 ]
 then

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -59,7 +59,7 @@ fi
 
 # Ingest the tarball to the repository
 echo "Ingesting tarball ${tar_file} to ${repo}..."
-${decompress} "${tar_file}" | cvmfs_server ingest -t - -b "${version}" "${repo}"
+${decompress} "${tar_file}" | cvmfs_server ingest -t - -b versions/"${version}" "${repo}"
 ec=$?
 if [ $ec -eq 0 ]
 then


### PR DESCRIPTION
As we've added this new `versions` directory to the root (see #32), the ingestion script should be using this in order to ingest to the right location.