### PR TITLE
Playbook for updating symlinks and files in the CVMFS repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 hosts
-roles/
+roles/galaxyproject.cvmfs
+roles/geerlingguy.repo-epel

--- a/README.md
+++ b/README.md
@@ -89,13 +89,17 @@ First install the Stratum 0 server:
 ansible-playbook -b -K -e @inventory/local_site_specific_vars.yml stratum0.yml
 ```
 
-Then install the files for the configuration repository:
-```
-ansible-playbook -b -K -e @inventory/local_site_specific_vars.yml stratum0-deploy-cvmfs-config.yml
-```
-
 Note that there can be only one Stratum 0, so you should only run this playbook
 for testing purposes or in case we need to move or redeploy the current Stratum 0 server.
+
+An additional playbook `create_cvmfs_content_structure.yml`, which runs the Ansible role `roles/create_cvmfs_content_structure`,
+can be used to automatically deploy certain files and symlinks to the EESSI CVMFS repositories.
+The list of files and symlinks can be defined in `roles/create_cvmfs_content_structure/vars`,
+where you can add files `<name of the CVMFS repo>.yml`.
+A cron job can be used on the Stratum 0 or a publisher node to periodically check for changes in these files, 
+and to push updates to your repo.
+In order to do this, clone this `filesystem-layer` repository, and let your cron job do a `git pull` followed by
+a run of the playbook (e.g. `ansible-playbook --connection=local create_cvmfs_content_structure.yml`).
 
 ### Stratum 1
 Installing a Stratum 1 requires a GEO API license key, which will be used to find

--- a/create_cvmfs_content_structure.yml
+++ b/create_cvmfs_content_structure.yml
@@ -1,0 +1,6 @@
+# Sync files to CVMFS repositories on a publisher node.
+---
+- name: Sync files to CVMFS repositories
+  hosts: cvmfsstratum0servers
+  roles:
+    - create_cvmfs_content_structure

--- a/roles/create_cvmfs_content_structure/defaults/main.yml
+++ b/roles/create_cvmfs_content_structure/defaults/main.yml
@@ -1,3 +1,3 @@
 cvmfs_start_transaction: yes
-cvmfs_publish_transaction: no
+cvmfs_publish_transaction: yes
 cvmfs_abort_transaction_on_failures: yes

--- a/roles/create_cvmfs_content_structure/defaults/main.yml
+++ b/roles/create_cvmfs_content_structure/defaults/main.yml
@@ -1,0 +1,3 @@
+cvmfs_start_transaction: yes
+cvmfs_publish_transaction: no
+cvmfs_abort_transaction_on_failures: yes

--- a/roles/create_cvmfs_content_structure/files/.cvmfsdirtab
+++ b/roles/create_cvmfs_content_structure/files/.cvmfsdirtab
@@ -1,0 +1,30 @@
+# Compatibility layer paths:
+# /2021.06/compat/{linux,macos}/{aarch64,ppc64le,x86_64}
+/2021.06/compat/*/*
+/2021.06/compat/*/*/var
+/2021.06/compat/*/*/var/db/repos
+
+# Software layer paths:
+# /2021.06/software/{linux,macos}/{aarch64,ppc64le,x86_64}/<vendor>/<microarchitecture>/software
+/2021.06/software/*/*/*/*/software
+/2021.06/software/*/*/*/*/software/*/*
+/2021.06/software/*/*/*/*/modules
+# generic and graviton2 are one level less deep
+/2021.06/software/*/*/*/software
+/2021.06/software/*/*/*/software/*/*
+/2021.06/software/*/*/*/modules
+
+# /versions/<version>/compat/{linux,macos}/{aarch64,ppc64le,x86_64}
+/versions/*/compat/*/*
+/versions/*/compat/*/*/var
+/versions/*/compat/*/*/var/db/repos
+
+# Software layer paths:
+# /versions/<version>/software/{linux,macos}/{aarch64,ppc64le,x86_64}/<vendor>/<microarchitecture>/software
+/versions/*/software/*/*/*/*/software
+/versions/*/software/*/*/*/*/software/*/*
+/versions/*/software/*/*/*/*/modules
+# generic and graviton2 are one level less deep
+/versions/*/software/*/*/*/software
+/versions/*/software/*/*/*/software/*/*
+/versions/*/software/*/*/*/modules

--- a/roles/create_cvmfs_content_structure/tasks/do_repo.yml
+++ b/roles/create_cvmfs_content_structure/tasks/do_repo.yml
@@ -1,0 +1,38 @@
+# Create symlinks in the CVMFS repository. 
+---
+
+- name: "Include the vars file for {{ cvmfs_repo }}"
+  include_vars: "{{ cvmfs_repo }}.yml"
+
+- name: Start transaction
+  command: "cvmfs_server transaction {{ cvmfs_repo }}"
+  when: cvmfs_start_transaction
+
+- block:
+
+  - name: "Create symlinks"
+    file:
+      path: "/cvmfs/{{ cvmfs_repo }}/{{ item }}"
+      src: "{{ symlinks[item] }}"
+      state: link
+      force: yes
+    with_items: "{{ symlinks }}"
+
+  - name: "Create files"
+    copy:
+      dest: "/cvmfs/{{ cvmfs_repo }}/{{ item }}"
+      content: "{{ files[item] }}"
+    with_items: "{{ files }}"
+
+  - name: Publish transaction
+    command: "cvmfs_server publish {{ cvmfs_repo }}"
+    when: cvmfs_start_transaction and cvmfs_publish_transaction
+
+  rescue:
+    - name: Abort transaction
+      command: "cvmfs_server abort {{ cvmfs_repo }}"
+      when: cvmfs_start_transaction and cvmfs_abort_transaction_on_failures
+
+    - name: Exit because of failure
+      fail:
+        msg: "Task {{ ansible_failed_task }} failed, with result {{ ansible_failed_result }}."

--- a/roles/create_cvmfs_content_structure/tasks/do_repo.yml
+++ b/roles/create_cvmfs_content_structure/tasks/do_repo.yml
@@ -1,4 +1,4 @@
-# Create symlinks in the CVMFS repository. 
+# Create specified files and symlinks in the CVMFS repository {{ cvmfs_repo }}. 
 ---
 
 - name: "Include the vars file for {{ cvmfs_repo }}"

--- a/roles/create_cvmfs_content_structure/tasks/do_repo.yml
+++ b/roles/create_cvmfs_content_structure/tasks/do_repo.yml
@@ -1,4 +1,4 @@
-# Create specified files and symlinks in the CVMFS repository {{ cvmfs_repo }}. 
+# Create specified files and symlinks in the CVMFS repository {{ cvmfs_repo }}.
 ---
 
 - name: "Include the vars file for {{ cvmfs_repo }}"

--- a/roles/create_cvmfs_content_structure/tasks/do_repo.yml
+++ b/roles/create_cvmfs_content_structure/tasks/do_repo.yml
@@ -20,8 +20,9 @@
 
   - name: "Create files"
     copy:
-      dest: "/cvmfs/{{ cvmfs_repo }}/{{ item }}"
-      content: "{{ files[item] }}"
+      dest: "/cvmfs/{{ cvmfs_repo }}/{{ item.path }}"
+      content: "{{ item.content }}"
+      mode: "{{ item.mode }}"
     with_items: "{{ files }}"
 
   - name: Publish transaction

--- a/roles/create_cvmfs_content_structure/tasks/do_repo.yml
+++ b/roles/create_cvmfs_content_structure/tasks/do_repo.yml
@@ -18,10 +18,10 @@
       force: yes
     with_items: "{{ symlinks }}"
 
-  - name: "Create files"
+  - name: "Copy files"
     copy:
-      dest: "/cvmfs/{{ cvmfs_repo }}/{{ item.path }}"
-      content: "{{ item.content }}"
+      src: "{{ item.name }}"
+      dest: "/cvmfs/{{ cvmfs_repo }}/{{ item.dest }}"
       mode: "{{ item.mode }}"
     with_items: "{{ files }}"
 

--- a/roles/create_cvmfs_content_structure/tasks/main.yml
+++ b/roles/create_cvmfs_content_structure/tasks/main.yml
@@ -1,0 +1,27 @@
+# Main task which:
+# -
+---
+
+- name: "Find which repositories have a vars file..."
+  delegate_to: localhost
+  stat:
+    path: "{{ role_path }}/vars/{{ item.repository }}.yml"
+  with_items: "{{ eessi_cvmfs_repositories }}"
+  register: repo_vars_file
+
+- name: Debug
+  debug:
+    msg: "{{ repo_vars_file }}"
+
+- name: "Apply do_repo for each repository with a vars file"
+  include_tasks: do_repo.yml
+  vars:
+    cvmfs_repo: "{{ repo_vars_file.item.repository }}"
+  when: repo_vars_file.stat.exists
+  with_items: "{{ repo_vars_file.results }}"
+  loop_control:
+    loop_var: repo_vars_file
+  args:
+    apply:
+      become: "{{ 'yes' if repo_vars_file.item.owner == 'root' else 'no' }}"
+

--- a/roles/create_cvmfs_content_structure/tasks/main.yml
+++ b/roles/create_cvmfs_content_structure/tasks/main.yml
@@ -1,5 +1,4 @@
-# Main task which:
-# -
+# Main task which runs do_repo.yml for every CVMFS repo with a vars file.
 ---
 
 - name: "Find which repositories have a vars file..."
@@ -8,10 +7,6 @@
     path: "{{ role_path }}/vars/{{ item.repository }}.yml"
   with_items: "{{ eessi_cvmfs_repositories }}"
   register: repo_vars_file
-
-- name: Debug
-  debug:
-    msg: "{{ repo_vars_file }}"
 
 - name: "Apply do_repo for each repository with a vars file"
   include_tasks: do_repo.yml

--- a/roles/create_cvmfs_content_structure/vars/pilot.eessi-hpc.org.yml
+++ b/roles/create_cvmfs_content_structure/vars/pilot.eessi-hpc.org.yml
@@ -24,3 +24,4 @@ files:
 symlinks:
   latest: 2021.06
   host_injections: '$(EESSI_HOST_INJECTIONS:-/opt/eessi)'
+  versions/2021.06: 2021.06

--- a/roles/create_cvmfs_content_structure/vars/pilot.eessi-hpc.org.yml
+++ b/roles/create_cvmfs_content_structure/vars/pilot.eessi-hpc.org.yml
@@ -1,3 +1,5 @@
+# Specifications of files and symlinks for the pilot.eessi-hpc.org CVMFS repository.
+# Paths for files and symlinks should be relative to the root of the repository.
 ---
 files:
   - path: .cvmfsdirtab

--- a/roles/create_cvmfs_content_structure/vars/pilot.eessi-hpc.org.yml
+++ b/roles/create_cvmfs_content_structure/vars/pilot.eessi-hpc.org.yml
@@ -2,26 +2,11 @@
 # Paths for files and symlinks should be relative to the root of the repository.
 ---
 files:
-  - path: .cvmfsdirtab
-    mode: 0644
-    content: |
-      # Compatibility layer paths:
-      # /<version>/compat/{linux,macos}/{aarch64,ppc64le,x86_64}
-      /*/compat/*/*
-      /*/compat/*/*/var
-      /*/compat/*/*/var/db/repos
-
-      # Software layer paths:
-      # /<version>/software/{linux,macos}/{aarch64,ppc64le,x86_64}/<vendor>/<microarchitecture>/software
-      /*/software/*/*/*/*/software
-      /*/software/*/*/*/*/software/*/*
-      /*/software/*/*/*/*/modules
-      # generic and graviton2 are one level less deep
-      /*/software/*/*/*/software
-      /*/software/*/*/*/software/*/*
-      /*/software/*/*/*/modules
+  - name: .cvmfsdirtab
+    dest: ''
+    mode: '644'
 
 symlinks:
   latest: 2021.06
   host_injections: '$(EESSI_HOST_INJECTIONS:-/opt/eessi)'
-  versions/2021.06: 2021.06
+  versions/2021.06: ../2021.06

--- a/roles/create_cvmfs_content_structure/vars/pilot.eessi-hpc.org.yml
+++ b/roles/create_cvmfs_content_structure/vars/pilot.eessi-hpc.org.yml
@@ -1,0 +1,21 @@
+files:
+  .cvmfsdirtab: |
+    # Compatibility layer paths:
+    # /<version>/compat/{linux,macos}/{aarch64,ppc64le,x86_64}
+    /*/compat/*/*
+    /*/compat/*/*/var
+    /*/compat/*/*/var/db/repos
+
+    # Software layer paths:
+    # /<version>/software/{linux,macos}/{aarch64,ppc64le,x86_64}/<vendor>/<microarchitecture>/software
+    /*/software/*/*/*/*/software
+    /*/software/*/*/*/*/software/*/*
+    /*/software/*/*/*/*/modules
+    # generic and graviton2 are one level less deep
+    /*/software/*/*/*/software
+    /*/software/*/*/*/software/*/*
+    /*/software/*/*/*/modules
+
+symlinks:
+  latest: 2021.06
+  host_injections: '$(EESSI_HOST_INJECTIONS:-/opt/eessi)'

--- a/roles/create_cvmfs_content_structure/vars/pilot.eessi-hpc.org.yml
+++ b/roles/create_cvmfs_content_structure/vars/pilot.eessi-hpc.org.yml
@@ -1,20 +1,23 @@
+---
 files:
-  .cvmfsdirtab: |
-    # Compatibility layer paths:
-    # /<version>/compat/{linux,macos}/{aarch64,ppc64le,x86_64}
-    /*/compat/*/*
-    /*/compat/*/*/var
-    /*/compat/*/*/var/db/repos
+  - path: .cvmfsdirtab
+    mode: 0644
+    content: |
+      # Compatibility layer paths:
+      # /<version>/compat/{linux,macos}/{aarch64,ppc64le,x86_64}
+      /*/compat/*/*
+      /*/compat/*/*/var
+      /*/compat/*/*/var/db/repos
 
-    # Software layer paths:
-    # /<version>/software/{linux,macos}/{aarch64,ppc64le,x86_64}/<vendor>/<microarchitecture>/software
-    /*/software/*/*/*/*/software
-    /*/software/*/*/*/*/software/*/*
-    /*/software/*/*/*/*/modules
-    # generic and graviton2 are one level less deep
-    /*/software/*/*/*/software
-    /*/software/*/*/*/software/*/*
-    /*/software/*/*/*/modules
+      # Software layer paths:
+      # /<version>/software/{linux,macos}/{aarch64,ppc64le,x86_64}/<vendor>/<microarchitecture>/software
+      /*/software/*/*/*/*/software
+      /*/software/*/*/*/*/software/*/*
+      /*/software/*/*/*/*/modules
+      # generic and graviton2 are one level less deep
+      /*/software/*/*/*/software
+      /*/software/*/*/*/software/*/*
+      /*/software/*/*/*/modules
 
 symlinks:
   latest: 2021.06


### PR DESCRIPTION
This playbook creates the files and symlinks defined in the `vars` file of the corresponding CVMFS repo. I'm planning to set up a cronjob on the Stratum 0 that periodically does a `git pull` and runs the playbook.

Still WIP, as I want to add some README/documentation.

Closes #89. Closes #51. Closes #34. 