### PR TITLE
Use latest version of prebuilt fuse-overlayfs binary, and bump versions of CVMFS, awscli, Debian for client and build containers

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -27,8 +27,8 @@ jobs:
         # [optional]
         # Arguments to override a package and its version to be set explicitly.
         # Must follow the example syntax.
+        # stick to older version of rich, as the new one is not compatible (yet) with ansible-lint
         override-deps: |
-          # stick to older version of rich, as the new one is not compatible (yet) with ansible-lint
           rich>=9.5.1,<11.0.0
         #  ansible==2.9
         #  ansible-lint==4.2.0

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -27,7 +27,9 @@ jobs:
         # [optional]
         # Arguments to override a package and its version to be set explicitly.
         # Must follow the example syntax.
-        #override-deps: |
+        override-deps: |
+          # stick to older version of rich, as the new one is not compatible (yet) with ansible-lint
+          rich>=9.5.1,<11.0.0
         #  ansible==2.9
         #  ansible-lint==4.2.0
         # [optional]

--- a/containers/Dockerfile.EESSI-build-node-debian10
+++ b/containers/Dockerfile.EESSI-build-node-debian10
@@ -2,13 +2,13 @@ ARG cvmfsversion=2.9.1
 ARG awscliversion=1.22.33
 ARG fuseoverlayfsversion=1.8
 
-FROM debian:10.6 AS prepare-deb
+FROM debian:10.11 AS prepare-deb
 ARG cvmfsversion
 COPY ./containers/build-or-download-cvmfs-debs.sh /build-or-download-cvmfs-debs.sh
 RUN sh /build-or-download-cvmfs-debs.sh ${cvmfsversion}
 
 
-FROM debian:10.6
+FROM debian:10.11
 ARG cvmfsversion
 ARG awscliversion
 ARG fuseoverlayfsversion

--- a/containers/Dockerfile.EESSI-build-node-debian10
+++ b/containers/Dockerfile.EESSI-build-node-debian10
@@ -1,4 +1,4 @@
-ARG cvmfsversion=2.9.1
+ARG cvmfsversion=2.9.0
 ARG awscliversion=1.22.33
 ARG fuseoverlayfsversion=1.8
 

--- a/containers/Dockerfile.EESSI-build-node-debian10
+++ b/containers/Dockerfile.EESSI-build-node-debian10
@@ -1,5 +1,5 @@
 ARG cvmfsversion=2.9.1
-ARG awscliversion=1.20.39
+ARG awscliversion=1.22.33
 ARG fuseoverlayfsversion=1.8
 
 FROM debian:10.6 AS prepare-deb

--- a/containers/Dockerfile.EESSI-build-node-debian10
+++ b/containers/Dockerfile.EESSI-build-node-debian10
@@ -1,5 +1,6 @@
 ARG cvmfsversion=2.8.2
 ARG awscliversion=1.20.39
+ARG fuseoverlayfsversion=1.8
 
 FROM debian:10.6 AS prepare-deb
 ARG cvmfsversion
@@ -10,6 +11,7 @@ RUN sh /build-or-download-cvmfs-debs.sh ${cvmfsversion}
 FROM debian:10.6
 ARG cvmfsversion
 ARG awscliversion
+ARG fuseoverlayfsversion
 
 COPY --from=prepare-deb /root/deb /root/deb
 
@@ -21,7 +23,10 @@ RUN dpkg -i /root/deb/cvmfs_${cvmfsversion}~1+debian10_$(dpkg --print-architectu
             /root/deb/cvmfs-fuse3_${cvmfsversion}~1+debian10_$(dpkg --print-architecture).deb \
             /root/deb/cvmfs-config-default_latest_all.deb \
             /root/deb/cvmfs-config-eessi_latest_all.deb
-RUN apt-get install -y fuse-overlayfs
+
+# download binary for specific version of fuse-overlayfs
+RUN curl -L -o /usr/local/bin/fuse-overlayfs https://github.com/containers/fuse-overlayfs/releases/download/v${fuseoverlayfsversion}/fuse-overlayfs-$(uname -m) \
+  && chmod +x /usr/local/bin/fuse-overlayfs
 
 RUN echo 'CVMFS_QUOTA_LIMIT=10000' > /etc/cvmfs/default.local \
   && echo 'CVMFS_CLIENT_PROFILE="single"' >> /etc/cvmfs/default.local

--- a/containers/Dockerfile.EESSI-build-node-debian10
+++ b/containers/Dockerfile.EESSI-build-node-debian10
@@ -1,4 +1,4 @@
-ARG cvmfsversion=2.8.2
+ARG cvmfsversion=2.9.1
 ARG awscliversion=1.20.39
 ARG fuseoverlayfsversion=1.8
 

--- a/containers/Dockerfile.EESSI-client-pilot-centos7
+++ b/containers/Dockerfile.EESSI-client-pilot-centos7
@@ -1,7 +1,5 @@
 ARG cvmfsversion=2.8.2
-# Stick to old version of fuse-overlayfs due to issues with newer versions
-# (cfr. https://github.com/containers/fuse-overlayfs/issues/232)
-ARG fuseoverlayfsversion=0.3
+ARG fuseoverlayfsversion=1.8
 
 FROM centos:7 AS prepare-rpm
 ARG cvmfsversion
@@ -9,17 +7,9 @@ COPY ./containers/build-or-download-cvmfs-rpms.sh /build-or-download-cvmfs-rpms.
 RUN sh /build-or-download-cvmfs-rpms.sh ${cvmfsversion}
 
 
-FROM centos:7 AS build-fuse-overlayfs
-ARG fuseoverlayfsversion
-RUN yum install -y wget fuse3-devel autoconf automake gcc make tar
-RUN wget https://github.com/containers/fuse-overlayfs/archive/refs/tags/v${fuseoverlayfsversion}.tar.gz \
-  && tar xzf v${fuseoverlayfsversion}.tar.gz \
-  && cd fuse-overlayfs-${fuseoverlayfsversion} \
-  && ./autogen.sh && ./configure && make && make install
-
-
 FROM centos:7
 ARG cvmfsversion
+ARG fuseoverlayfsversion
 
 COPY --from=prepare-rpm /root/rpmbuild/RPMS /root/rpmbuild/RPMS
 COPY --from=build-fuse-overlayfs /usr/local/bin/fuse-overlayfs /usr/local/bin/fuse-overlayfs
@@ -29,6 +19,10 @@ RUN yum install -y /root/rpmbuild/RPMS/$(uname -m)/cvmfs-${cvmfsversion}-1.el7.$
                    /root/rpmbuild/RPMS/$(uname -m)/cvmfs-fuse3-${cvmfsversion}-1.el7.$(uname -m).rpm \
                    http://ecsft.cern.ch/dist/cvmfs/cvmfs-config/cvmfs-config-default-latest.noarch.rpm
 RUN yum install -y https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi-latest.noarch.rpm
+
+# download binary for specific version of fuse-overlayfs
+RUN curl -L -o /usr/local/bin/fuse-overlayfs https://github.com/containers/fuse-overlayfs/releases/download/v${fuseoverlayfsversion}/fuse-overlayfs-$(uname -m) \
+  && chmod +x /usr/local/bin/fuse-overlayfs
 
 RUN echo 'CVMFS_QUOTA_LIMIT=10000' > /etc/cvmfs/default.local \
   && echo 'CVMFS_CLIENT_PROFILE="single"' >> /etc/cvmfs/default.local

--- a/containers/Dockerfile.EESSI-client-pilot-centos7
+++ b/containers/Dockerfile.EESSI-client-pilot-centos7
@@ -1,4 +1,4 @@
-ARG cvmfsversion=2.8.2
+ARG cvmfsversion=2.9.1
 ARG fuseoverlayfsversion=1.8
 
 FROM centos:7 AS prepare-rpm

--- a/containers/Dockerfile.EESSI-client-pilot-centos7
+++ b/containers/Dockerfile.EESSI-client-pilot-centos7
@@ -1,4 +1,4 @@
-ARG cvmfsversion=2.9.1
+ARG cvmfsversion=2.9.0
 ARG fuseoverlayfsversion=1.8
 
 FROM centos:7 AS prepare-rpm

--- a/containers/Dockerfile.EESSI-client-pilot-centos7
+++ b/containers/Dockerfile.EESSI-client-pilot-centos7
@@ -12,7 +12,6 @@ ARG cvmfsversion
 ARG fuseoverlayfsversion
 
 COPY --from=prepare-rpm /root/rpmbuild/RPMS /root/rpmbuild/RPMS
-COPY --from=build-fuse-overlayfs /usr/local/bin/fuse-overlayfs /usr/local/bin/fuse-overlayfs
 
 RUN yum install -y sudo vim openssh-clients lsof
 RUN yum install -y /root/rpmbuild/RPMS/$(uname -m)/cvmfs-${cvmfsversion}-1.el7.$(uname -m).rpm \

--- a/containers/build-or-download-cvmfs-debs.sh
+++ b/containers/build-or-download-cvmfs-debs.sh
@@ -5,7 +5,7 @@ apt-get update
 apt-get install -y wget
 if [ "$arch" = "ppc64el" ] || [ "$arch" = "arm64" ]
 then
-    apt-get install -y devscripts libfuse3-dev cmake cpio libcap-dev libssl-dev libfuse-dev pkg-config libattr1-dev python-dev python-setuptools uuid-dev valgrind libz-dev lsb-release
+    apt-get install -y devscripts libfuse3-dev cmake cpio libcap-dev libssl-dev libfuse-dev pkg-config libattr1-dev python-dev python-setuptools python3-setuptools uuid-dev valgrind libz-dev lsb-release
     cd /tmp
     wget https://github.com/cvmfs/cvmfs/archive/refs/tags/cvmfs-${cvmfsversion}.tar.gz
     tar xzf cvmfs-${cvmfsversion}.tar.gz


### PR DESCRIPTION
The new version of fuse-overlayfs doesn't seem to be affected by the `Operation not permitted` issue (see https://github.com/containers/fuse-overlayfs/issues/232) anymore when used in a Singularity container. So, instead of sticking to the default (very old) version that Debian 10 provides, or building that old version manually for CentOS 7, we can now simply grab the prebuilt binary from the release page.