### PR TITLE
revert update to fuse-overlayfs 1.8 back to 0.3, since 'Operation not permitted' errors still occur...

### DIFF
--- a/containers/Dockerfile.EESSI-build-node-debian10
+++ b/containers/Dockerfile.EESSI-build-node-debian10
@@ -1,6 +1,5 @@
 ARG cvmfsversion=2.9.0
 ARG awscliversion=1.22.33
-ARG fuseoverlayfsversion=1.8
 
 FROM debian:10.11 AS prepare-deb
 ARG cvmfsversion
@@ -11,7 +10,6 @@ RUN sh /build-or-download-cvmfs-debs.sh ${cvmfsversion}
 FROM debian:10.11
 ARG cvmfsversion
 ARG awscliversion
-ARG fuseoverlayfsversion
 
 COPY --from=prepare-deb /root/deb /root/deb
 
@@ -25,8 +23,11 @@ RUN dpkg -i /root/deb/cvmfs_${cvmfsversion}~1+debian10_$(dpkg --print-architectu
             /root/deb/cvmfs-config-eessi_latest_all.deb
 
 # download binary for specific version of fuse-overlayfs
-RUN curl -L -o /usr/local/bin/fuse-overlayfs https://github.com/containers/fuse-overlayfs/releases/download/v${fuseoverlayfsversion}/fuse-overlayfs-$(uname -m) \
-  && chmod +x /usr/local/bin/fuse-overlayfs
+# RUN curl -L -o /usr/local/bin/fuse-overlayfs https://github.com/containers/fuse-overlayfs/releases/download/v${fuseoverlayfsversion}/fuse-overlayfs-$(uname -m) \
+#   && chmod +x /usr/local/bin/fuse-overlayfs
+# Stick to old version of fuse-overlayfs due to issues with newer versions
+# (cfr. https://github.com/containers/fuse-overlayfs/issues/232)
+RUN apt-get install -y fuse-overlayfs
 
 RUN echo 'CVMFS_QUOTA_LIMIT=10000' > /etc/cvmfs/default.local \
   && echo 'CVMFS_CLIENT_PROFILE="single"' >> /etc/cvmfs/default.local

--- a/containers/Dockerfile.EESSI-client-pilot-centos7
+++ b/containers/Dockerfile.EESSI-client-pilot-centos7
@@ -21,7 +21,7 @@ RUN wget https://github.com/containers/fuse-overlayfs/archive/refs/tags/v${fuseo
 FROM centos:7
 ARG cvmfsversion
 
-OPY --from=prepare-rpm /root/rpmbuild/RPMS /root/rpmbuild/RPMS
+COPY --from=prepare-rpm /root/rpmbuild/RPMS /root/rpmbuild/RPMS
 COPY --from=build-fuse-overlayfs /usr/local/bin/fuse-overlayfs /usr/local/bin/fuse-overlayfs
 
 RUN yum install -y sudo vim openssh-clients lsof

--- a/containers/Dockerfile.EESSI-client-pilot-centos7
+++ b/containers/Dockerfile.EESSI-client-pilot-centos7
@@ -1,5 +1,7 @@
 ARG cvmfsversion=2.9.0
-ARG fuseoverlayfsversion=1.8
+# Stick to old version of fuse-overlayfs due to issues with newer versions
+# (cfr. https://github.com/containers/fuse-overlayfs/issues/232)
+ARG fuseoverlayfsversion=0.3
 
 FROM centos:7 AS prepare-rpm
 ARG cvmfsversion
@@ -7,11 +9,20 @@ COPY ./containers/build-or-download-cvmfs-rpms.sh /build-or-download-cvmfs-rpms.
 RUN sh /build-or-download-cvmfs-rpms.sh ${cvmfsversion}
 
 
+FROM centos:7 AS build-fuse-overlayfs
+ARG fuseoverlayfsversion
+RUN yum install -y wget fuse3-devel autoconf automake gcc make tar
+RUN wget https://github.com/containers/fuse-overlayfs/archive/refs/tags/v${fuseoverlayfsversion}.tar.gz \
+  && tar xzf v${fuseoverlayfsversion}.tar.gz \
+  && cd fuse-overlayfs-${fuseoverlayfsversion} \
+  && ./autogen.sh && ./configure && make && make install
+
+
 FROM centos:7
 ARG cvmfsversion
-ARG fuseoverlayfsversion
 
-COPY --from=prepare-rpm /root/rpmbuild/RPMS /root/rpmbuild/RPMS
+OPY --from=prepare-rpm /root/rpmbuild/RPMS /root/rpmbuild/RPMS
+COPY --from=build-fuse-overlayfs /usr/local/bin/fuse-overlayfs /usr/local/bin/fuse-overlayfs
 
 RUN yum install -y sudo vim openssh-clients lsof
 RUN yum install -y /root/rpmbuild/RPMS/$(uname -m)/cvmfs-${cvmfsversion}-1.el7.$(uname -m).rpm \


### PR DESCRIPTION
This reverts the `fuse-overlayfs` update from #113, because the `Operation not permitted` persists after all when testing the new build container (on Azure `zen3`):

```
eessi@kh-zen3-build-node ~/software-layer $ EESSI_SOFTWARE_SUBDIR_OVERRIDE='x86_64/amd/zen3' ./EESSI-pilot-install-software.sh
>> Setting up environment...
/cvmfs/pilot.eessi-hpc.org available, OK!
>> It looks like we're in a Gentoo Prefix environment, good!
>> Determining software subdirectory to use for current build host...
>> Using x86_64/amd/zen3 as software subdirectory!
>> Initializing Lmod...
>> Found Lmod 8.5.6
>> Configuring EasyBuild...
>> Setting up $MODULEPATH...
>> MODULEPATH set up: /cvmfs/pilot.eessi-hpc.org/versions/2021.12/software/linux/x86_64/amd/zen3/modules/all
>> Checking for EasyBuild module...
>> No EasyBuild module yet, installing it...
>> Temporary installation (in /tmp/tmp.SmlwZ35K8d/ebtmp)...
>> Final installation in /cvmfs/pilot.eessi-hpc.org/versions/2021.12/software/linux/x86_64/amd/zen3...
1
== taking care of extensions...
== ... (took < 1 sec)
== restore after iterating...
== ... (took < 1 sec)
== postprocessing...
== ... (took < 1 sec)
== sanity checking...
== ... (took < 1 sec)
== FAILED: Installation ended unsuccessfully (build directory: /tmp/boegel/easybuild/build/EasyBuild/4.5.0/dummy-dummy): build failed (first 300 chars): Failed to change from /dev/shm/boegel/easybuild/build/EasyBuild/4.5.0/dummy-dummy/easybuild-easyconfigs-4.5.0 to /cvmfs/pilot.eessi-hpc.org/versions/2021.12/software/linux/x86_64/amd/zen3/software/EasyBuild/4.5.0: [Errno 1] Operation not permitted: '/cvmfs/pilot.eessi-hpc.org/versions/2021.12/softwa (took 14 secs)
== Results of the build can be found in the log file(s) /tmp/eb-t582rlzy/easybuild-EasyBuild-4.5.0-20220114.202202.GfUBg.log
```