### PR TITLE
Fix CI issues with Ubuntu 18.04 and CentOS 8 containers, and with macOS CVMFS tests

### DIFF
--- a/.github/workflows/Dockerfile-rockylinux-8
+++ b/.github/workflows/Dockerfile-rockylinux-8
@@ -1,4 +1,4 @@
-FROM centos:centos8
+FROM rockylinux:8
 
 USER root
 

--- a/.github/workflows/Dockerfile-ubuntu-18.04
+++ b/.github/workflows/Dockerfile-ubuntu-18.04
@@ -5,6 +5,7 @@ USER root
 RUN apt-get update
 RUN apt-get install -y cron gpg python3.8 python3-pip systemd
 
+RUN python3.8 -m pip install -U pip
 RUN python3.8 -m pip install ansible
 
 COPY ./.github/workflows/test-playbook.sh /test-playbook.sh

--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -230,7 +230,7 @@ jobs:
 
   test-macos-package:
     needs: build-macos-package
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - name: Install OSXFUSE
         run: brew install --cask macfuse

--- a/.github/workflows/test-playbooks.yml
+++ b/.github/workflows/test-playbooks.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         component: [stratum0, stratum1, localproxy, client]
-        os: [centos-7, centos-8, ubuntu-18.04, ubuntu-20.04]
+        os: [centos-7, rockylinux-8, ubuntu-18.04, ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
       - name: Make temporary directory for /srv


### PR DESCRIPTION
CentOS 8 is not supported anymore, so I've replaced it by a Rocky container. The Ubuntu 18.04 container had issues with installing ansible's dependency markupsafe (see: https://github.com/pallets/markupsafe/issues/285), so I fixed that by first upgrading pip.