### PR TITLE
Change the publish transaction to trigger correctly

### DIFF
--- a/roles/create_cvmfs_content_structure/tasks/do_repo.yml
+++ b/roles/create_cvmfs_content_structure/tasks/do_repo.yml
@@ -32,7 +32,7 @@
     when:
       - cvmfs_start_transaction
       - cvmfs_publish_transaction
-      - (create_symlinks.changed) or (create_files.changed)
+      - create_symlinks.changed or create_files.changed
     register: publish
 
   - name: Abort transaction

--- a/roles/create_cvmfs_content_structure/tasks/do_repo.yml
+++ b/roles/create_cvmfs_content_structure/tasks/do_repo.yml
@@ -32,8 +32,7 @@
     when:
       - cvmfs_start_transaction
       - cvmfs_publish_transaction
-      - create_symlinks.changed
-      - create_files.changed
+      - (create_symlinks.changed) or (create_files.changed)
     register: publish
 
   - name: Abort transaction


### PR DESCRIPTION
The current publish transaction only triggers when symlinks and files are changed, with this edit it will publish when one of them is changed.