### PR TITLE
update build container to Debian 11.5 + CernVM-FS 2.10.0 + fuse-overlayfs 1.9 + awscli 1.27.8

### DIFF
--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        tag: ['client-pilot:centos7', 'build-node:debian10']
+        tag: ['client-pilot:centos7', 'build-node:debian11']
         platform: [amd64, arm64, ppc64le]
 
     steps:
@@ -88,7 +88,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        tag: ['client-pilot:centos7', 'build-node:debian10']
+        tag: ['client-pilot:centos7', 'build-node:debian11']
     steps:
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/containers/Dockerfile.EESSI-build-node-debian11
+++ b/containers/Dockerfile.EESSI-build-node-debian11
@@ -1,15 +1,17 @@
-ARG cvmfsversion=2.9.4
-ARG awscliversion=1.25.69
+ARG cvmfsversion=2.10.0
+ARG awscliversion=1.27.8
+ARG fuseoverlayfsversion=1.9
 
-FROM debian:10.11 AS prepare-deb
+FROM debian:11.5 AS prepare-deb
 ARG cvmfsversion
 COPY ./containers/build-or-download-cvmfs-debs.sh /build-or-download-cvmfs-debs.sh
 RUN sh /build-or-download-cvmfs-debs.sh ${cvmfsversion}
 
 
-FROM debian:10.11
+FROM debian:11.5
 ARG cvmfsversion
 ARG awscliversion
+ARG fuseoverlayfsversion
 
 COPY --from=prepare-deb /root/deb /root/deb
 
@@ -17,17 +19,14 @@ RUN apt-get update
 RUN apt-get install -y sudo vim openssh-client gawk autofs curl attr uuid fuse3 libfuse2 psmisc gdb uuid-dev lsof
 # python3 and jq are required for eessi-upload-to-staging script (next to awscli)
 RUN apt-get install -y python3-pip jq
-RUN dpkg -i /root/deb/cvmfs_${cvmfsversion}~1+debian10_$(dpkg --print-architecture).deb \
-            /root/deb/cvmfs-fuse3_${cvmfsversion}~1+debian10_$(dpkg --print-architecture).deb \
+RUN dpkg -i /root/deb/cvmfs_${cvmfsversion}~1+debian11_$(dpkg --print-architecture).deb \
+            /root/deb/cvmfs-fuse3_${cvmfsversion}~1+debian11_$(dpkg --print-architecture).deb \
             /root/deb/cvmfs-config-default_latest_all.deb \
             /root/deb/cvmfs-config-eessi_latest_all.deb
 
 # download binary for specific version of fuse-overlayfs
-# RUN curl -L -o /usr/local/bin/fuse-overlayfs https://github.com/containers/fuse-overlayfs/releases/download/v${fuseoverlayfsversion}/fuse-overlayfs-$(uname -m) \
-#   && chmod +x /usr/local/bin/fuse-overlayfs
-# Stick to old version of fuse-overlayfs due to issues with newer versions
-# (cfr. https://github.com/containers/fuse-overlayfs/issues/232)
-RUN apt-get install -y fuse-overlayfs
+RUN curl -L -o /usr/local/bin/fuse-overlayfs https://github.com/containers/fuse-overlayfs/releases/download/v${fuseoverlayfsversion}/fuse-overlayfs-$(uname -m) \
+  && chmod +x /usr/local/bin/fuse-overlayfs
 
 RUN echo 'CVMFS_QUOTA_LIMIT=10000' > /etc/cvmfs/default.local \
   && echo 'CVMFS_CLIENT_PROFILE="single"' >> /etc/cvmfs/default.local \

--- a/containers/README.md
+++ b/containers/README.md
@@ -39,7 +39,7 @@ export SINGULARITY_BIND="$EESSI_TMPDIR/var-run-cvmfs:/var/run/cvmfs,$EESSI_TMPDI
 export SINGULARITY_HOME="$EESSI_TMPDIR/home:/home/$USER"
 export EESSI_PILOT_READONLY="container:cvmfs2 pilot.eessi-hpc.org /cvmfs_ro/pilot.eessi-hpc.org"
 export EESSI_PILOT_WRITABLE_OVERLAY="container:fuse-overlayfs -o lowerdir=/cvmfs_ro/pilot.eessi-hpc.org -o upperdir=$EESSI_TMPDIR/overlay-upper -o workdir=$EESSI_TMPDIR/overlay-work /cvmfs/pilot.eessi-hpc.org"
-singularity shell --fusemount "$EESSI_PILOT_READONLY" --fusemount "$EESSI_PILOT_WRITABLE_OVERLAY" docker://ghcr.io/eessi/build-node:debian10
+singularity shell --fusemount "$EESSI_PILOT_READONLY" --fusemount "$EESSI_PILOT_WRITABLE_OVERLAY" docker://ghcr.io/eessi/build-node:debian11
 ```
 
 For more details about building software, see: https://eessi.github.io/docs/software_layer/build_nodes/

--- a/containers/build-or-download-cvmfs-debs.sh
+++ b/containers/build-or-download-cvmfs-debs.sh
@@ -1,5 +1,7 @@
+#/bin/bash
 cvmfsversion=$1
 arch=$(dpkg --print-architecture)
+os=debian11
 
 apt-get update
 apt-get install -y wget
@@ -19,8 +21,8 @@ then
 else
     mkdir -p /root/deb
     cd /root/deb
-    wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs_${cvmfsversion}~1+debian10_${arch}.deb
-    wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs-fuse3_${cvmfsversion}~1+debian10_${arch}.deb
+    wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs_${cvmfsversion}~1+${os}_${arch}.deb
+    wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs-fuse3_${cvmfsversion}~1+${os}_${arch}.deb
 fi
 
 cd /root/deb


### PR DESCRIPTION
This seems to fix the weird problem I was running into when installing `Qt5-5.15.2-GCCcore-10.3.0.eb` when I was using an AWS VM as a build node that is discussed in detail in https://github.com/easybuilders/easybuild-easyconfigs/issues/16614:
```
/tmp/boegel/easybuild/build/Qt5/5.15.2/GCCcore-10.3.0/qt-everywhere-src-5.15.2/qtbase/bin/qmake -install qinstall /tmp/boegel/easybuild/build/Qt5/5.15.2/GCCcore-10.3.0/qt-everywhere-src-5.15.2/qtbase/include/QtGui/QGenericPlugin /cvmfs/pilot.eessi-hpc.org/versions/2021.12/software/linux/aarch64/graviton3/software/Qt5/5.15.2-GCCcore-10.3.0/include/QtGui/QGenericPlugin
Error copying /tmp/boegel/easybuild/build/Qt5/5.15.2/GCCcore-10.3.0/qt-everywhere-src-5.15.2/qtbase/include/QtGui/QGenericPlugin to /cvmfs/pilot.eessi-hpc.org/versions/2021.12/software/linux/aarch64/graviton3/software/Qt5/5.15.2-GCCcore-10.3.0/include/QtGui/QGenericPlugin: Cannot create /cvmfs/pilot.eessi-hpc.org/versions/2021.12/software/linux/aarch64/graviton3/software/Qt5/5.15.2-GCCcore-10.3.0/include/QtGui/QGenericPlugin for output
make[3]: *** [Makefile:87752: install_gen_headers] Error 3
```

There were some weird symptoms with the old `fuse-overlayfs` version (v0.3) that suggest we were hitting a bug, which only seems to manifest on AWS VMs for some reason (probably related to the filesystem type that's being used for the overlay directories).

In addition, it looks like using `fuse-overlayfs` v1.9 in Debian 11.5 finally fixes the problems we had we recent versions of `fuse-overlayfs` (cfr. https://github.com/containers/fuse-overlayfs/issues/232) 🥳 

Once the build container image is rebuilt, we'll also need to update the `build_container.sh` script in the [https://github.com/EESSI/software-layer/](https://github.com/EESSI/software-layer/) repo (to use `debian11` instead of `debian10`).