### PR TITLE
Fix tarball content type check

### DIFF
--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -220,7 +220,7 @@ fi
 tar_file_basename=$(basename "${tar_file}")
 version=$(echo "${tar_file_basename}" | cut -d- -f2)
 contents_type_dir=$(echo "${tar_file_basename}" | cut -d- -f3)
-tar_first_file=$(tar tf "${tar_file}" | head -n 1)
+tar_first_file=$(tar tf "${tar_file}" | head -n 2 | tail -n 1)
 tar_top_level_dir=$(echo "${tar_first_file}" | cut -d/ -f1)
 tar_contents_type_dir=$(echo "${tar_first_file}" | head -n 2 | tail -n 1 | cut -d/ -f2)
 

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -220,6 +220,7 @@ fi
 tar_file_basename=$(basename "${tar_file}")
 version=$(echo "${tar_file_basename}" | cut -d- -f2)
 contents_type_dir=$(echo "${tar_file_basename}" | cut -d- -f3)
+# use the second file, as the first one may be the top-level (version) directory, e.g. 2021.12
 tar_first_file=$(tar tf "${tar_file}" | head -n 2 | tail -n 1)
 tar_top_level_dir=$(echo "${tar_first_file}" | cut -d/ -f1)
 tar_contents_type_dir=$(echo "${tar_first_file}" | head -n 2 | tail -n 1 | cut -d/ -f2)


### PR DESCRIPTION
First entry of `tar tzf <tarball>` may be e.g. `2021.12/`, so use the second one instead (and it will still use the first one if there is only a single file in the tarball).