### PR TITLE
stick to fuse-overlayfs v1.10 in build container, since v1.12 again triggers 'Operation not permitted' error for basic operations

### DIFF
--- a/containers/Dockerfile.EESSI-build-node-debian11
+++ b/containers/Dockerfile.EESSI-build-node-debian11
@@ -1,6 +1,6 @@
 ARG cvmfsversion=2.10.1
 ARG awscliversion=1.27.146
-ARG fuseoverlayfsversion=1.12
+ARG fuseoverlayfsversion=1.10
 
 FROM debian:11.7 AS prepare-deb
 ARG cvmfsversion


### PR DESCRIPTION
cfr. https://github.com/containers/fuse-overlayfs/issues/232#issuecomment-1578273859