### PR TITLE
Fix workflow for building client packages

### DIFF
--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -31,16 +31,10 @@ jobs:
           [[ $REF_NAME == refs/tags/v* ]] && VERSION=${REF_NAME/refs\/tags\/v/}
           echo ::set-output name=version::${VERSION}
 
-      # The next step uses a custom Ansible inventory, and due to that it cannot find
-      # the group_vars folder inside the inventory folder. This symlink fixes that.
-      - name: Make symlink to group_vars
-        run: ln -s inventory/group_vars
-
-      - name: Prepare package source
-        uses: roles-ansible/check-ansible-debian-stable-action@bc4b37806481d66df213c1a8d5c59495ed7801f0
-        with:
-          targets: "./prepare-client-packages.yml"
-          hosts: "localhost"
+      - name: Prepare package source by running the corresponding playbook locally
+        run: |
+          echo "localhost ansible_connection=local" > inventory/hosts
+          ansible-playbook ./prepare-client-packages.yml
 
 # We probably should loop over the set {rpm,deb,osxpkg} to create packages, but
 # it will make debugging more annoying.


### PR DESCRIPTION
This removes the dependency on an external action, and directly calls Ansible in the runner (should already be available according to https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#tools).

Fixes #155.