### PR TITLE
Reduce the number of calls to the GitHub API

### DIFF
--- a/scripts/automated_ingestion/automated_ingestion.py
+++ b/scripts/automated_ingestion/automated_ingestion.py
@@ -92,7 +92,7 @@ def main():
     logging.basicConfig(filename=log_file, format=log_format, level=log_level)
     # TODO: check configuration: secrets, paths, permissions on dirs, etc
     gh_pat = config['secrets']['github_pat']
-    gh = github.Github(gh_pat)
+    gh_staging_repo = github.Github(gh_pat).get_repo(config['github']['staging_repo'])
     s3 = boto3.client(
         's3',
         aws_access_key_id=config['secrets']['aws_access_key_id'],
@@ -107,7 +107,7 @@ def main():
                 print(f'[{bucket}] {num}: {tarball}')
         else:
             for tarball in tarballs:
-                tar = EessiTarball(tarball, config, gh, s3, bucket)
+                tar = EessiTarball(tarball, config, gh_staging_repo, s3, bucket)
                 tar.run_handler()
 
 

--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -22,7 +22,6 @@ class EessiTarball:
     def __init__(self, object_name, config, git_staging_repo, s3, bucket):
         """Initialize the tarball object."""
         self.config = config
-        self.github = github
         self.git_repo = git_staging_repo
         self.metadata_file = object_name + config['paths']['metadata_file_extension']
         self.object = object_name

--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -19,11 +19,11 @@ class EessiTarball:
     for which it interfaces with the S3 bucket, GitHub, and CVMFS.
     """
 
-    def __init__(self, object_name, config, github, s3, bucket):
+    def __init__(self, object_name, config, git_staging_repo, s3, bucket):
         """Initialize the tarball object."""
         self.config = config
         self.github = github
-        self.git_repo = github.get_repo(config['github']['staging_repo'])
+        self.git_repo = git_staging_repo
         self.metadata_file = object_name + config['paths']['metadata_file_extension']
         self.object = object_name
         self.s3 = s3


### PR DESCRIPTION
Instead of calling `get_repo()` for every tarball, just call it once and pass it to the tarball objects.