### PR TITLE
Rename eessi.io public key

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -18,7 +18,7 @@ eessi_cvmfs_config_repo: {}
 # /etc/cvmfs/keys/*.pub
 # Note: you first have to run the stratum0.yml playbook once to generate the repositories and keys.
 eessi_cvmfs_keys:
-  - path: /etc/cvmfs/keys/eessi.io/software.eessi.io.pub
+  - path: /etc/cvmfs/keys/eessi.io/eessi.io.pub
     key: |
       -----BEGIN PUBLIC KEY-----
       MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyau1UFUcoiqpE5U9StON


### PR DESCRIPTION
As we will use only one masterkey, and hence one public key, for all `eessi.io` repos, I've applied the suggestion from Dave in https://github.com/cvmfs-contrib/config-repo/pull/206/files here as well and renamed the pubkey to `eessi.io.pub`.