### PR TITLE
Small fixes for cvmfs_server_meta_info role

### DIFF
--- a/roles/cvmfs_server_meta_info/tasks/main.yml
+++ b/roles/cvmfs_server_meta_info/tasks/main.yml
@@ -7,7 +7,7 @@
     group: root
     mode: 0644
   become: true
-  when: (cvmfs_repositories | length) > 0
+  when: (cvmfs_repositories | default(eessi_cvmfs_repositories, true) | length) > 0
 
 - name: Create meta information for each CVMFS repository
   ansible.builtin.include_tasks: repo_meta_info.yml
@@ -18,6 +18,6 @@
       recommended-stratum0: "http://{{ item.stratum0 }}/cvmfs/{{ item.repository }}"
       recommended-stratum1s: "{{ eessi_cvmfs_server_urls | selectattr('domain', 'in', item.repository) |
                                  map(attribute='urls') | map('regex_replace', '@fqrn@', item.repository) }}"
-  with_items: "{{ cvmfs_repositories | default(eessi_cvmfs_repositories) }}"
-  when: "'cvmfsstratum0servers' in group_names or cvmfs_role == 'stratum0'"
+  with_items: "{{ cvmfs_repositories | default(eessi_cvmfs_repositories, true) }}"
+  when: ('cvmfsstratum0servers' in group_names and inventory_hostname in groups['cvmfsstratum0servers']) or cvmfs_role == 'stratum0'
 ...

--- a/roles/cvmfs_server_meta_info/tasks/repo_meta_info.yml
+++ b/roles/cvmfs_server_meta_info/tasks/repo_meta_info.yml
@@ -26,6 +26,7 @@
   ansible.builtin.command:
     cmd: "cvmfs_server update-repoinfo -f {{ tmp_json_file.path }} {{ this_cvmfs_repo.repository }}"
   when: (current_repo_meta.stdout | checksum) != json_file_stat.stat.checksum
+  become: true
   become_user: "{{ cvmfs_repo_owner | default('root') }}"
 
 - name: Remove temporary json file


### PR DESCRIPTION
Ran into this when I was trying to apply it to the new server/repo. The `default(...., true)` makes sure that the default is also used when the variable is an empty list (instead of undefined only). 