### PR TITLE
Include `eessi-hpc.org` domain configuration in new EESSI CVMFS configuration

### DIFF
--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -36,6 +36,11 @@ jobs:
           echo "localhost ansible_connection=local" > inventory/hosts
           ansible-playbook ./prepare-client-packages.yml
 
+      - name: Include the old eessi-hpc.org config as well for now
+        run: |
+          wget https://github.com/EESSI/filesystem-layer/releases/download/v0.4.0/cvmfs-config-eessi-0.4.0.tar
+          tar xf cvmfs-config-eessi-0.4.0.tar
+
 # We probably should loop over the set {rpm,deb,osxpkg} to create packages, but
 # it will make debugging more annoying.
 

--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -128,8 +128,11 @@ jobs:
       - name: Download and install CVMFS client
         run: wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb && sudo dpkg -i cvmfs-release-latest_all.deb
 
+      - name: Download and install cvmfs-config-none package
+        run: wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-config/cvmfs-config-none_1.1-0_all.deb && sudo dpkg -i cvmfs-config-none_1.1-0_all.deb
+
       - name: Install CVMFS client
-        run: sudo apt-get update && sudo apt-get install cvmfs cvmfs-config-none
+        run: sudo apt-get update && sudo apt-get install cvmfs
 
       - name: Download cvmfs-config-eessi package
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
@@ -164,7 +167,7 @@ jobs:
 
     steps:
       - name: Download and install CVMFS client
-        run: yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm
+        run: yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && yum-config-manager --enable cernvm-config
 
       - name: Install CVMFS client
         run: yum install -y cvmfs cvmfs-config-none
@@ -204,8 +207,11 @@ jobs:
       - name: Download and install CVMFS client
         run: wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb && sudo dpkg -i cvmfs-release-latest_all.deb
 
+      - name: Download and install cvmfs-config-none package
+        run: wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-config/cvmfs-config-none_1.1-0_all.deb && sudo dpkg -i cvmfs-config-none_1.1-0_all.deb
+
       - name: Install CVMFS client
-        run: sudo apt-get update && sudo apt-get install cvmfs cvmfs-config-none
+        run: sudo apt-get update && sudo apt-get install cvmfs
 
       - name: Download cvmfs-config-eessi package
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1

--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -129,7 +129,7 @@ jobs:
         run: wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb && sudo dpkg -i cvmfs-release-latest_all.deb
 
       - name: Install CVMFS client
-        run: sudo apt-get update && sudo apt-get install cvmfs
+        run: sudo apt-get update && sudo apt-get install cvmfs cvmfs-config-none
 
       - name: Download cvmfs-config-eessi package
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
@@ -167,7 +167,7 @@ jobs:
         run: yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm
 
       - name: Install CVMFS client
-        run: yum install -y cvmfs
+        run: yum install -y cvmfs cvmfs-config-none
 
       - name: Download cvmfs-config-eessi package
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
@@ -205,7 +205,7 @@ jobs:
         run: wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb && sudo dpkg -i cvmfs-release-latest_all.deb
 
       - name: Install CVMFS client
-        run: sudo apt-get update && sudo apt-get install cvmfs
+        run: sudo apt-get update && sudo apt-get install cvmfs cvmfs-config-none
 
       - name: Download cvmfs-config-eessi package
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1

--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Include the old eessi-hpc.org config as well for now
         run: |
           wget https://github.com/EESSI/filesystem-layer/releases/download/v0.4.0/cvmfs-config-eessi-0.4.0.tar
-          tar xf cvmfs-config-eessi-0.4.0.tar
+          tar -C ./package -xf cvmfs-config-eessi-0.4.0.tar
           rm cvmfs-config-eessi-0.4.0.tar
 
 # We probably should loop over the set {rpm,deb,osxpkg} to create packages, but

--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           wget https://github.com/EESSI/filesystem-layer/releases/download/v0.4.0/cvmfs-config-eessi-0.4.0.tar
           tar xf cvmfs-config-eessi-0.4.0.tar
+          rm cvmfs-config-eessi-0.4.0.tar
 
 # We probably should loop over the set {rpm,deb,osxpkg} to create packages, but
 # it will make debugging more annoying.


### PR DESCRIPTION
The new client package only contained the `eessi.io` configuration. By (temporarily) including the old config as well, we can ensure that people (and our build container recipes) can always grab the latest package without breaking any workflows/instructions, because they will have access to both.