### PR TITLE
Fix issue with creating multi-platform Docker images

### DIFF
--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -82,8 +82,8 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  create_manifest:
-    name: Create the Docker manifest
+  create_multiplatform_image:
+    name: Create the multi-platform Docker image
     needs: build_and_publish
     runs-on: ubuntu-latest
     permissions:
@@ -105,15 +105,14 @@ jobs:
         run: |
           echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
-      - name: Run docker manifest
+      - name: Create the final image using  "docker buildx imagetools create"
         if: github.event_name != 'pull_request'
         run: |
-          docker manifest create \
-            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }} \
-            --amend ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-amd64 \
-            --amend ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-arm64 \
-            --amend ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-ppc64le
+          docker buildx imagetools create -t ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }} \
+            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-amd64 \
+            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-arm64 \
+            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-ppc64le
 
-      - name: Push manifest
+      - name: Inspect the final image
         if: github.event_name != 'pull_request'
-        run: docker manifest push ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}
+        run: docker buildx imagetools inspect ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}


### PR DESCRIPTION
The CI that builds our Docker images failed in the last step after merging #171. This step runs `docker manifest` to create a multi-platform Docker image based on the individual images that are built for each architecture. Not sure why that doesn't work anymore, but I found an alternative that uses `docker buildx imagetools`. Also see:
https://docs.docker.com/engine/reference/commandline/buildx_imagetools_create/
https://stackoverflow.com/a/75742743
https://github.com/docker/buildx/issues/1509

Tested this in a test repo:
https://github.com/bedroge/dockertest
https://github.com/bedroge/dockertest/pkgs/container/client