### PR TITLE
Bump `awscli` to 1.32.22 in build container

### DIFF
--- a/containers/Dockerfile.EESSI-build-node-debian11
+++ b/containers/Dockerfile.EESSI-build-node-debian11
@@ -1,5 +1,5 @@
 ARG cvmfsversion=2.11.2
-ARG awscliversion=1.30.2
+ARG awscliversion=1.32.22
 ARG fuseoverlayfsversion=1.10
 
 FROM debian:11.7 AS prepare-deb


### PR DESCRIPTION
Just making a small change here to trigger the updated CI (see #173) and rebuild our container images, as it failed after merging #171.