### PR TITLE
Add script for updating Lmod caches

### DIFF
--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -168,6 +168,23 @@ function check_arch() {
     fi
 }
 
+function update_lmod_caches() {
+    # Update the Lmod caches for the stacks of all supported CPUs
+    script_dir=$(dirname $(realpath $BASH_SOURCE))
+    update_caches_script=${script_dir}/update_lmod_caches.sh
+    if [ ! -f ${update_caches_script} ]
+    then
+        error "cannot find the script for updating the Lmod caches; it should be placed in the same directory as the ingestion script!"
+    fi
+    if [ ! -x ${update_caches_script} ]
+    then
+        error "the script for updating the Lmod caches (${update_caches_script}) does not have execute permissions!"
+    fi
+    cvmfs_server transaction "${repo}"
+    ${update_caches_script} /cvmfs/${repo}/${basedir}/${version}
+    cvmfs_server publish -m "update Lmod caches after ingesting ${tar_file_basename}" "${repo}"
+}
+
 function ingest_init_tarball() {
     # Handle the ingestion of tarballs containing init scripts
     cvmfs_ingest_tarball
@@ -183,6 +200,7 @@ function ingest_software_tarball() {
     check_arch
     check_os
     cvmfs_ingest_tarball
+    update_lmod_caches
 }
 
 function ingest_compat_tarball() {

--- a/scripts/update_lmod_caches.sh
+++ b/scripts/update_lmod_caches.sh
@@ -41,5 +41,12 @@ for archdir in ${architectures}
 do
   lmod_cache_dir="${archdir}/.lmod/cache"
   ${update_lmod_system_cache_files} -d ${lmod_cache_dir} -t ${lmod_cache_dir}/timestamp ${archdir}/modules/all
-  echo_green "Updated the Lmod cache for ${archdir}."
+  exit_code=$?
+  if [[ ${exit_code} -eq 0 ]]; then
+      echo_green "Updated the Lmod cache for ${archdir}."
+      ls -lrt ${lmod_cache_dir}
+  else
+      echo_red "Updating the Lmod cache failed for ${archdir}."
+      exit ${exit_code}
+  fi
 done

--- a/scripts/update_lmod_caches.sh
+++ b/scripts/update_lmod_caches.sh
@@ -26,7 +26,7 @@ then
   error "${stack_base_dir} does not point to an existing directory!"
 fi
 
-# Check if Lmod's cache update script can be found at the expected location (in the compatibility layer of the gien stack)
+# Check if Lmod's cache update script can be found at the expected location (in the compatibility layer of the given stack)
 update_lmod_system_cache_files="${stack_base_dir}/compat/linux/$(uname -m)/usr/share/Lmod/libexec/update_lmod_system_cache_files"
 if [ ! -f ${update_lmod_system_cache_files} ]
 then

--- a/scripts/update_lmod_caches.sh
+++ b/scripts/update_lmod_caches.sh
@@ -36,34 +36,10 @@ fi
 # Find all subtrees of supported CPU targets by looking for "modules" directories, and taking their parent directory
 architectures=$(find ${stack_base_dir}/software/ -maxdepth 5 -type d -name modules -exec dirname {} \;)
 
-# For every subtree:
-# - create an .lmod directory;
-# - add an lmodrc.lua file that defines the location of the cache;
-# - create or update the cache.
+# Create/update the Lmod cache for all architectures
 for archdir in ${architectures}
 do
-  DOT_LMOD="${archdir}/.lmod"
-  LMOD_RC="${archdir}/.lmod/lmodrc.lua"
-
-  if [ ! -d "${DOT_LMOD}" ]
-  then
-    mkdir -p "${DOT_LMOD}/cache"
-  fi
-
-  if [ ! -f "${LMOD_RC}" ]
-  then
-    cat > "${LMOD_RC}" <<LMODRCEOF
-propT = {
-}
-scDescriptT = {
-    {
-        ["dir"] = "${DOT_LMOD}/cache",
-        ["timestamp"] = "${DOT_LMOD}/cache/timestamp",
-    },
-}
-LMODRCEOF
-  fi
-
-  ${update_lmod_system_cache_files=} -d ${DOT_LMOD}/cache -t ${DOT_LMOD}/cache/timestamp ${archdir}/modules/all
+  lmod_cache_dir="${archdir}/.lmod/cache"
+  ${update_lmod_system_cache_files=} -d ${lmod_cache_dir} -t ${lmod_cache_dir}/timestamp ${archdir}/modules/all
   echo_green "Updated the Lmod cache for ${archdir}."
 done

--- a/scripts/update_lmod_caches.sh
+++ b/scripts/update_lmod_caches.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+function echo_green() {
+    echo -e "\e[32m$1\e[0m"
+}
+
+function echo_red() {
+    echo -e "\e[31m$1\e[0m"
+}
+
+function error() {
+    echo_red "ERROR: $1" >&2
+    exit 1
+}
+
+# Check if a stack base dir has been specified
+if [ "$#" -ne 1 ]; then
+    error "usage: $0 <path to main directory of an EESSI stack>"
+fi
+
+stack_base_dir="$1"
+
+# Check if the given stack base dir exists
+if [ ! -d ${stack_base_dir} ]
+then
+  error "${stack_base_dir} does not point to an existing directory!"
+fi
+
+# Check if Lmod's cache update script can be found at the expected location (in the compatibility layer of the gien stack)
+update_lmod_system_cache_files="${stack_base_dir}/compat/linux/$(uname -m)/usr/share/Lmod/libexec/update_lmod_system_cache_files"
+if [ ! -f ${update_lmod_system_cache_files} ]
+then
+  error "expected to find Lmod's cache update script at ${update_lmod_system_cache_files}, but it doesn't exist."
+fi
+
+# Find all subtrees of supported CPU targets by looking for "modules" directories, and taking their parent directory
+architectures=$(find ${stack_base_dir}/software/ -maxdepth 5 -type d -name modules -exec dirname {} \;)
+
+# For every subtree:
+# - create an .lmod directory;
+# - add an lmodrc.lua file that defines the location of the cache;
+# - create or update the cache.
+for archdir in ${architectures}
+do
+  DOT_LMOD="${archdir}/.lmod"
+  LMOD_RC="${archdir}/.lmod/lmodrc.lua"
+
+  if [ ! -d "${DOT_LMOD}" ]
+  then
+    mkdir -p "${DOT_LMOD}/cache"
+  fi
+
+  if [ ! -f "${LMOD_RC}" ]
+  then
+    cat > "${LMOD_RC}" <<LMODRCEOF
+propT = {
+}
+scDescriptT = {
+    {
+        ["dir"] = "${DOT_LMOD}/cache",
+        ["timestamp"] = "${DOT_LMOD}/cache/timestamp",
+    },
+}
+LMODRCEOF
+  fi
+
+  ${update_lmod_system_cache_files=} -d ${DOT_LMOD}/cache -t ${DOT_LMOD}/cache/timestamp ${archdir}/modules/all
+  echo_green "Updated the Lmod cache for ${archdir}."
+done

--- a/scripts/update_lmod_caches.sh
+++ b/scripts/update_lmod_caches.sh
@@ -40,6 +40,6 @@ architectures=$(find ${stack_base_dir}/software/ -maxdepth 5 -type d -name modul
 for archdir in ${architectures}
 do
   lmod_cache_dir="${archdir}/.lmod/cache"
-  ${update_lmod_system_cache_files=} -d ${lmod_cache_dir} -t ${lmod_cache_dir}/timestamp ${archdir}/modules/all
+  ${update_lmod_system_cache_files} -d ${lmod_cache_dir} -t ${lmod_cache_dir}/timestamp ${archdir}/modules/all
   echo_green "Updated the Lmod cache for ${archdir}."
 done


### PR DESCRIPTION
Closes https://github.com/EESSI/software-layer/issues/167. Could perhaps be made a bit smarter by only updating the cache of the subtree that's being modified. But that's a bit more effort (can be taken from the filename of the tarball), and may not work anymore if we want to combine all tarballs into a single one.