### PR TITLE
Bump FPM action to latest commit

### DIFF
--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -46,19 +46,19 @@ jobs:
 # it will make debugging more annoying.
 
       - name: Build RPM package
-        uses: bpicode/github-action-fpm@e76c0e2166030f4691d641a700b16958c7d12f5d # v0.9.2
+        uses: bpicode/github-action-fpm@7502b06a5a58390398d4002bd284f8cb3caae6eb
         with:
           fpm_args: "etc"
           fpm_opts: "--debug -n cvmfs-config-eessi -v ${{ steps.get_version.outputs.version }} -t rpm -a all -s dir -C ./package --description 'CVMFS configuration package for EESSI.'"
 
       - name: Build Deb package
-        uses: bpicode/github-action-fpm@e76c0e2166030f4691d641a700b16958c7d12f5d # v0.9.2
+        uses: bpicode/github-action-fpm@7502b06a5a58390398d4002bd284f8cb3caae6eb
         with:
           fpm_args: "etc"
           fpm_opts: "--debug -n cvmfs-config-eessi -v ${{ steps.get_version.outputs.version }} -t deb -a all -s dir -C ./package --description 'CVMFS configuration package for EESSI.'"
 
       - name: Build tar package
-        uses: bpicode/github-action-fpm@e76c0e2166030f4691d641a700b16958c7d12f5d # v0.9.2
+        uses: bpicode/github-action-fpm@7502b06a5a58390398d4002bd284f8cb3caae6eb
         with:
           fpm_args: "etc"
           fpm_opts: "--debug -n cvmfs-config-eessi-${{ steps.get_version.outputs.version }} -t tar -a all -s dir -C ./package --description 'CVMFS configuration package for EESSI.'"


### PR DESCRIPTION
This should solve the failing CI (see #177) for building our packages:
```
  #11 [6/7] RUN gem install --no-document fpm -v 1.11.0
  #11 48.39 ERROR:  Error installing fpm:
  #11 48.39 	The last version of dotenv (>= 0) to support your Ruby & RubyGems was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1` and then running the current command again
  #11 48.39 	dotenv requires Ruby version >= 3.0. The current ruby version is 2.7.8.225.
  #11 48.64 Successfully installed stud-0.0.23
  #11 ERROR: process "/bin/sh -c gem install --no-document fpm -v 1.11.0" did not complete successfully: exit code: 1
```