### PR TITLE
Use our fork of the `ansible-cvmfs` role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 build
 hosts
-roles/galaxyproject.cvmfs
-roles/geerlingguy.repo-epel

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ and, if necessary, created machine-specific configuration files in `inventory/ho
 ### Firewalls
 To make all communication between the CVMFS services possible, some ports have to be opened on the Stratum 0 (default: port 80), 
 Stratum 1 (default: port 80 and 8000), and local proxy (default: port 3128).
-These default port numbers are listed in `roles/galaxyproject.cvmfs/defaults/main.yml`, but can be overridden in your local
-configuration file (`local_site_specific_vars.yml`).
+These default port numbers are listed in the file `defaults/main.yml` of the `ansible-cvmfs` role,
+but can be overridden in your local configuration file (`local_site_specific_vars.yml`).
 
 The Ansible playbook can update your firewall rules automatically (`firewalld` on Redhat systems, `ufw` on Debian systems), 
 but by default it will not do this. If you want to enable this functionality, set `cvmfs_manage_firewall` to `true`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and a role for adding the EPEL repository (https://github.com/geerlingguy/ansibl
 
 To download the dependency roles do:
 ```
-ansible-galaxy role install -r requirements.yml -p ./roles
+ansible-galaxy role install -r requirements.yml
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ For more details, see the Ansible installation guide: https://docs.ansible.com/a
 Note that Ansible needs to be able to log in to the remote machines where you want to install some CVMFS component,
 and needs to be able to use privilege escalation (e.g. `sudo`) on those machines to execute tasks with root permission.
 
-For the installation of all components we make use of two Ansible roles: the CVMFS installation role provided by the Galaxy project (see
-https://github.com/galaxyproject/ansible-cvmfs), and a role for adding the EPEL repository (https://github.com/geerlingguy/ansible-role-repo-epel).
+For the installation of all components we make use of two Ansible roles:
+the EESSI CVMFS installation role (see https://github.com/galaxyproject/ansible-cvmfs) 
+based on the one developed by the Galaxy project (see https://github.com/galaxyproject/ansible-cvmfs),
+and a role for adding the EPEL repository (https://github.com/geerlingguy/ansible-role-repo-epel).
 
 To download the dependency roles do:
 ```

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ In order to do this, clone this `filesystem-layer` repository, and let your cron
 a run of the playbook (e.g. `ansible-playbook --connection=local create_cvmfs_content_structure.yml`).
 
 ### Stratum 1
-Installing a Stratum 1 requires a GEO API license key, which will be used to find
+Installing a Stratum 1 requires a GEO API account id and license key, which will be used to find
 the (geographically) closest Stratum 1 server for your client and proxies.
 More information on how to (freely) obtain this key is available in the CVMFS documentation: 
 https://cvmfs.readthedocs.io/en/stable/cpt-replica.html#geo-api-setup .
 
-You can put your license key in the local configuration file `inventory/local_site_specific_vars.yml`. 
+You can put your account id and license key in the local configuration file `inventory/local_site_specific_vars.yml`. 
 
 Furthermore, the Stratum 1 runs a Squid server. The template configuration file can be found at 
 `templates/eessi_stratum1_squid.conf.j2`.

--- a/client.yml
+++ b/client.yml
@@ -3,4 +3,4 @@
 - name: CVMFS clients
   hosts: cvmfsclients
   roles:
-    - galaxyproject.cvmfs
+    - eessi.cvmfs

--- a/localproxy.yml
+++ b/localproxy.yml
@@ -3,4 +3,4 @@
 - name: CVMFS local proxies.
   hosts: cvmfslocalproxies
   roles:
-    - galaxyproject.cvmfs
+    - eessi.cvmfs

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
   - name: eessi.cvmfs
     src: https://github.com/EESSI/ansible-cvmfs
-    version: 91aab1d
+    version: 0af8e77
 
   - name: geerlingguy.repo-epel
     version: 3.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
   - name: eessi.cvmfs
     src: https://github.com/EESSI/ansible-cvmfs
-    version: 0af8e77
+    version: cd41783
 
   - name: geerlingguy.repo-epel
     version: 3.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
   - name: eessi.cvmfs
     src: https://github.com/EESSI/ansible-cvmfs
-    version: 9b6e0c4
+    version: be935e0
 
   - name: geerlingguy.repo-epel
     version: 3.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
   - name: eessi.cvmfs
     src: https://github.com/EESSI/ansible-cvmfs
-    version: f91be29
+    version: 91aab1d
 
   - name: geerlingguy.repo-epel
     version: 3.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,9 +3,9 @@
 # ansible-galaxy role install -r requirements.yml -p ./roles
 roles:
 
-  - name: galaxyproject.cvmfs
-    src: https://github.com/galaxyproject/ansible-cvmfs
-    version: 78b2e03
+  - name: eessi.cvmfs
+    src: https://github.com/EESSI/ansible-cvmfs
+    version: 9b6e0c4
 
   - name: geerlingguy.repo-epel
     version: 3.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
   - name: eessi.cvmfs
     src: https://github.com/EESSI/ansible-cvmfs
-    version: 8188eb8
+    version: cb7a4de
 
   - name: geerlingguy.repo-epel
     version: 3.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 
-# ansible-galaxy role install -r requirements.yml -p ./roles
+# ansible-galaxy role install -r requirements.yml
 roles:
 
   - name: eessi.cvmfs

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
   - name: eessi.cvmfs
     src: https://github.com/EESSI/ansible-cvmfs
-    version: cd41783
+    version: 8188eb8
 
   - name: geerlingguy.repo-epel
     version: 3.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
   - name: eessi.cvmfs
     src: https://github.com/EESSI/ansible-cvmfs
-    version: 2d0b958
+    version: f91be29
 
   - name: geerlingguy.repo-epel
     version: 3.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
   - name: eessi.cvmfs
     src: https://github.com/EESSI/ansible-cvmfs
-    version: be935e0
+    version: 2d0b958
 
   - name: geerlingguy.repo-epel
     version: 3.0.0

--- a/stratum0.yml
+++ b/stratum0.yml
@@ -2,16 +2,6 @@
 ---
 - name: CVMFS Stratum 0
   hosts: cvmfsstratum0servers
-  pre_tasks:
-    - name: Fix that adds additional dependencies for Debian systems
-      set_fact:
-        cvmfs_packages:
-          stratum0:
-            - apache2
-            - cvmfs-server
-            - cvmfs-config-default
-            - cvmfs
-      when: ansible_facts['os_family'] == 'Debian'
   roles:
     - role: geerlingguy.repo-epel
       when: ansible_facts['os_family'] == 'RedHat'

--- a/stratum0.yml
+++ b/stratum0.yml
@@ -15,7 +15,7 @@
   roles:
     - role: geerlingguy.repo-epel
       when: ansible_facts['os_family'] == 'RedHat'
-    - galaxyproject.cvmfs
+    - eessi.cvmfs
     - cvmfs_server_meta_info
     - create_cvmfs_content_structure
 ...

--- a/stratum1.yml
+++ b/stratum1.yml
@@ -16,6 +16,6 @@
   roles:
     - role: geerlingguy.repo-epel
       when: ansible_facts['os_family'] == 'RedHat'
-    - galaxyproject.cvmfs
+    - eessi.cvmfs
     - cvmfs_server_meta_info
 ...

--- a/stratum1.yml
+++ b/stratum1.yml
@@ -2,17 +2,6 @@
 ---
 - name: CVMFS Stratum 1
   hosts: cvmfsstratum1servers
-  pre_tasks:
-    - name: Fix that adds additional dependencies for Debian systems
-      set_fact:
-        cvmfs_packages:
-          stratum1:
-            - apache2
-            - "{{ 'libapache2-mod-wsgi-py3' if ansible_distribution_release in ('bookworm', 'jammy') else 'libapache2-mod-wsgi' }}"
-            - squid
-            - cvmfs-server
-            - cvmfs-config-default
-      when: ansible_facts['os_family'] == 'Debian'
   roles:
     - role: geerlingguy.repo-epel
       when: ansible_facts['os_family'] == 'RedHat'

--- a/templates/eessi_stratum1_squid.conf.j2
+++ b/templates/eessi_stratum1_squid.conf.j2
@@ -5,10 +5,11 @@
 # Contact dual-stack websites over IPv4 first
 dns_v4_first on
 
-http_port 80 accel
-http_port 8000 accel
+{% for port in cvmfs_stratum1_http_ports %}
+http_port {{ port }} accel
+{% endfor %}
 http_access allow all
-cache_peer 127.0.0.1 parent {{ cvmfs_stratum1_apache_port }} 0 no-query originserver
+cache_peer 127.0.0.1 parent {{ cvmfs_stratum1_apache_port_with_squid }} 0 no-query originserver
 
 {% if cvmfs_stratum1_cache_dir is defined %}
 cache_dir ufs {{ cvmfs_stratum1_cache_dir.dir }} {{ cvmfs_stratum1_cache_dir.size }} 16 256


### PR DESCRIPTION
I've forked https://github.com/galaxyproject/ansible-cvmfs to https://github.com/EESSI/ansible-cvmfs, and made some changes that we really need for S3 support and key directories. This PR changes the playbooks, README, and requirements file to use our fork.