### PR TITLE
Fix auto-update of Lmod caches

### DIFF
--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -180,9 +180,9 @@ function update_lmod_caches() {
     then
         error "the script for updating the Lmod caches (${update_caches_script}) does not have execute permissions!"
     fi
-    cvmfs_server transaction "${repo}"
+    ${cvmfs_server} transaction "${repo}"
     ${update_caches_script} /cvmfs/${repo}/${basedir}/${version}
-    cvmfs_server publish -m "update Lmod caches after ingesting ${tar_file_basename}" "${repo}"
+    ${cvmfs_server} publish -m "update Lmod caches after ingesting ${tar_file_basename}" "${repo}"
 }
 
 function ingest_init_tarball() {


### PR DESCRIPTION
The script sets `cvmfs_server="cvmfs_server"` and changes it to `sudo cvmfs_server` in case the user running it is not the owner of the repo. However, the Lmod cache update function did not use `$cvmfs_server`, which caused permission errors... 