### PR TITLE
try to determine common prefix for paths in tarball after filtering out `*/init/*` paths

### DIFF
--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -95,7 +95,15 @@ class EessiTarball:
 
         else:
             tar_members_desc = 'Summarized overview of the contents of the tarball:'
-            prefix = os.path.commonprefix(paths)
+            # determine prefix after filtering out '<EESSI version>/init' subdirectory,
+            # to get actual prefix for specific CPU target (like '2023.06/software/linux/aarch64/neoverse_v1')
+            init_subdir = os.path.join('*', 'init')
+            non_init_paths = sorted([p for p in paths if not any(x.match(init_subdir) for x in PurePosixPath(p).parents)])
+            if non_init_paths:
+                prefix = os.path.commonprefix(non_init_paths)
+            else:
+                prefix = os.path.commonprefix(paths)
+
             # TODO: this only works for software tarballs, how to handle compat layer tarballs?
             swdirs = [  # all directory names with the pattern: <prefix>/software/<name>/<version>
                 m.path


### PR DESCRIPTION
Tested this with `eessi-2023.06-software-linux-aarch64-a64fx-1719346462.tar.gz`, with these changes I get the following as `members_list` (as expected):

```
['2023.06/init/easybuild/eb_hooks.py',
 '2023.06/software/linux/aarch64/a64fx/modules/all/BLIS/0.9.0-GCC-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/CMake/3.26.3-GCCcore-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/FFTW.MPI/3.3.10-gompi-2023a.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/FFTW/3.3.10-GCC-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/FlexiBLAS/3.3.1-GCC-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/OpenBLAS/0.3.23-GCC-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/Python/3.11.3-GCCcore-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/SQLite/3.42.0-GCCcore-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/ScaLAPACK/2.2.0-gompi-2023a-fb.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/Tcl/8.6.13-GCCcore-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/UnZip/6.0-GCCcore-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/cURL/8.0.1-GCCcore-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/foss/2023a.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/gompi/2023a.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/libarchive/3.6.2-GCCcore-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/libffi/3.4.4-GCCcore-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/modules/all/make/4.4.1-GCCcore-12.3.0.lua',
 '2023.06/software/linux/aarch64/a64fx/software/BLIS/0.9.0-GCC-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/CMake/3.26.3-GCCcore-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/FFTW.MPI/3.3.10-gompi-2023a',
 '2023.06/software/linux/aarch64/a64fx/software/FFTW/3.3.10-GCC-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/FlexiBLAS/3.3.1-GCC-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/OpenBLAS/0.3.23-GCC-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/Python/3.11.3-GCCcore-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/SQLite/3.42.0-GCCcore-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/ScaLAPACK/2.2.0-gompi-2023a-fb',
 '2023.06/software/linux/aarch64/a64fx/software/Tcl/8.6.13-GCCcore-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/UnZip/6.0-GCCcore-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/cURL/8.0.1-GCCcore-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/foss/2023a',
 '2023.06/software/linux/aarch64/a64fx/software/gompi/2023a',
 '2023.06/software/linux/aarch64/a64fx/software/libarchive/3.6.2-GCCcore-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/libffi/3.4.4-GCCcore-12.3.0',
 '2023.06/software/linux/aarch64/a64fx/software/make/4.4.1-GCCcore-12.3.0']
```