### PR TITLE
Use latest commit of eessi.cvmfs

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
   - name: eessi.cvmfs
     src: https://github.com/EESSI/ansible-cvmfs
-    version: 1534b04
+    version: 34b6e07
 
   - name: geerlingguy.repo-epel
     version: 3.0.0


### PR DESCRIPTION
Let's see if this fixes the broken CI (https://github.com/EESSI/filesystem-layer/actions/runs/9676886245) by using the change from https://github.com/EESSI/ansible-cvmfs/pull/13.