### PR TITLE
[WIP] Add `admin.list` files to warn users of known issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build
 hosts
+*.list
+*-known-issues.yml

--- a/scripts/create_admin.list.py
+++ b/scripts/create_admin.list.py
@@ -3,28 +3,31 @@
 # Create admin.list file for Lmod.
 # This will use information from the known_issues.yaml file to display
 # a message to the user when they load a module that is known to have issues.
-#
 import os
 import yaml
 from urllib import request
 
+
 # Download the known issues YAML file from the EESSI/software-layer GitHub repository
-
-
-# Get known issues file
 # TODO: This hardcodes version 2023.06, we should make this dynamic
-url = 'https://raw.githubusercontent.com/EESSI/software-layer/2023.06-software.eessi.io/eessi-2023.06-known-issues.yml'
-r = request.urlretrieve(url, 'eessi-2023.06-known-issues.yml')
+KNOWN_ISSUES_FILE = 'eessi-2023.06-known-issues.yml'
+KNOWN_ISSUES_URL = 'https://raw.githubusercontent.com/EESSI/software-layer/2023.06-software.eessi.io/' + KNOWN_ISSUES_FILE
+r = request.urlretrieve(KNOWN_ISSUES_URL, KNOWN_ISSUES_FILE)
 
 # Open the YAML file
-with open('eessi-2023.06-known-issues.yml', 'r') as file:
-    # Load the YAML data
-    known_issues = yaml.safe_load(file)
+try:
+    with open(KNOWN_ISSUES_FILE, 'r') as file:
+        # Load the YAML data
+        known_issues = yaml.safe_load(file)
+except IOError:
+    raise IOError("Unable to open the known issues file")
 
 # Remove the admin.list file if it exists, we will recreate it
 if os.path.exists('admin.list'):
-    os.remove('admin.list')
-
+    try:
+        os.remove('admin.list')
+    except OSError:
+        raise OSError("Unable to remove the admin.list file")
 
 admin_list_file = open('admin.list', 'a')
 path = '/cvmfs/software.eessi.io/versions/2023.06/software/linux/'

--- a/scripts/create_admin.list.py
+++ b/scripts/create_admin.list.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+#
+# Create admin.list file for Lmod.
+# This will use information from the known_issues.yaml file to display
+# a message to the user when they load a module that is known to have issues.
+#
+import os
+import yaml
+from urllib import request
+
+# Download the known issues YAML file from the EESSI/software-layer GitHub repository
+
+
+# Get known issues file
+# TODO: This hardcodes version 2023.06, we should make this dynamic
+url = 'https://raw.githubusercontent.com/EESSI/software-layer/2023.06-software.eessi.io/eessi-2023.06-known-issues.yml'
+r = request.urlretrieve(url, 'eessi-2023.06-known-issues.yml')
+
+# Open the YAML file
+with open('eessi-2023.06-known-issues.yml', 'r') as file:
+    # Load the YAML data
+    known_issues = yaml.safe_load(file)
+
+# Remove the admin.list file if it exists, we will recreate it
+if os.path.exists('admin.list'):
+    os.remove('admin.list')
+
+
+admin_list_file = open('admin.list', 'a')
+path = '/cvmfs/software.eessi.io/versions/2023.06/software/linux/'
+for i in range(len(known_issues)):
+    arch, known_issues_arch = list(known_issues[i].items())[0]
+    for j in range(len(known_issues_arch)):
+        # Write known issue per arch and module
+        known_issues_module, known_issue = list(known_issues_arch[j].items())[0]
+        known_issues_module = known_issues_module.replace('/', '_')
+        module_path = os.path.join(path, 'modules/all', arch, known_issues_module)
+        message = f"{module_path}:"
+        message += (
+            f"\n   There is a known issue: {known_issue[1]['info']}"
+            f"\n   See: {known_issue[0]['issue']}\n\n"
+        )
+        admin_list_file.write(message)
+
+admin_list_file.close()

--- a/scripts/create_admin.list.py
+++ b/scripts/create_admin.list.py
@@ -22,17 +22,21 @@ try:
 except IOError:
     raise IOError("Unable to open the known issues file")
 
-# Remove the admin.list file if it exists, we will recreate it
-if os.path.exists('admin.list'):
-    try:
-        os.remove('admin.list')
-    except OSError:
-        raise OSError("Unable to remove the admin.list file")
-
-admin_list_file = open('admin.list', 'a')
+# Create a admin.list file per arch
 path = '/cvmfs/software.eessi.io/versions/2023.06/software/linux/'
 for i in range(len(known_issues)):
     arch, known_issues_arch = list(known_issues[i].items())[0]
+    admin_list_filename = f"admin.list.{arch}"
+
+    # Remove the admin.list file if it exists, we will recreate it
+    if os.path.exists(admin_list_filename):
+        try:
+            os.remove(admin_list_filename)
+        except OSError:
+            raise OSError(f"Unable to remove the {admin_list_filename} file")
+
+    # Open the admin.list file, with no dashes in the filename
+    admin_list_file = open(admin_list_filename.replace('/', '_'), 'a')
     for j in range(len(known_issues_arch)):
         # Write known issue per arch and module
         known_issues_module, known_issue = list(known_issues_arch[j].items())[0]


### PR DESCRIPTION
A small number of the software installed on EESSI has some issues in specific contexts that users should be made aware of (see support ticket [#79](https://gitlab.com/eessi/support/-/issues/79)).

This WIP PR adds `admin.list` files per architecture to use Lmod's [module deprecating feature](https://lmod.readthedocs.io/en/latest/140_deprecating_modules.html) in order to display a message to users when they load a module with known issues. The information about the known issues comes from the YAML file(s) in the root of the software-layer repository: [eessi-2023.06-known-issues.yml](https://github.com/EESSI/software-layer/blob/2023.06-software.eessi.io/eessi-2023.06-known-issues.yml)

The warnings should appear only in the context where they apply, i.e., a user using `zen4` CPUs shouldn't be warned about a few failing tests for SciPy in `neoverse_v1`.

The `admin.list` files should have the following format: 
```
/cvmfs/software.eessi.io/versions/2023.06/software/linux/modules/all/aarch64/neoverse_v1/ESPResSo/4.2.1-foss-2023a:
   There is a known issue: ESPResSo tests failing due to timeouts
   See: https://github.com/EESSI/software-layer/issues/363

/cvmfs/software.eessi.io/versions/2023.06/software/linux/modules/all/aarch64/neoverse_v1/FFTW/MPI-3.3.10-gompi-2023a:
   There is a known issue: Flaky FFTW tests, random failures
   See: https://github.com/EESSI/software-layer/issues/325
```

The first line can be a module name and version, but also the full path to a module. This is preferred, since it ensures that we are picking up the relevant module in the right context, and that we are not displaying unintended warnings should EESSI be mounted in a site that has repeating local installations of the same module.

This PR is marked as WIP because there is issue to solve still. Parsing the `known_issues.yml` file yields _almost_ the correct path, but the module directory is incorrect as it is the easyconfig name that is recorded and not the module name. Compare (note dash between module name and version):
Expected - `/cvmfs/software.eessi.io/versions/2023.06/software/linux/modules/all/aarch64/neoverse_v1/ESPResSo/4.2.1-foss-2023a` 
Obtained -  `/cvmfs/software.eessi.io/versions/2023.06/software/linux/modules/all/aarch64/neoverse_v1/ESPResSo-4.2.1-foss-2023a`

Converting between easyconfig name and module name is more complicated than I initially thought, because module names can be very variable and be composed of an unknown number of words.

I see two options: 
* Coming up with a clever trick for this, that could possibly fail in some more esoteric model names
* Modifying the problem upstream and converting the name in the `known_issues.yml` file to match the expected output.
