### PR TITLE
Handle longer `dev.eessi.io` prefix in ingestion

### DIFF
--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -258,7 +258,12 @@ version=$(echo "${tar_file_basename}" | cut -d- -f2)
 contents_type_dir=$(echo "${tar_file_basename}" | cut -d- -f3)
 tar_first_file=$(tar tf "${tar_file}" | head -n 1)
 tar_top_level_dir=$(echo "${tar_first_file}" | cut -d/ -f1)
-tar_contents_type_dir=$(tar tf "${tar_file}" | head -n 2 | tail -n 1 | cut -d/ -f2)
+# Handle longer prefix with project name in dev.eessi.io
+if [ "${cvmfs_repo}" = "dev.eessi.io" ]; then
+    tar_contents_type_dir=$(tar tf "${tar_file}" | head -n 2 | tail -n 1 | cut -d/ -f3)
+else
+    tar_contents_type_dir=$(tar tf "${tar_file}" | head -n 2 | tail -n 1 | cut -d/ -f2)
+fi
 
 # Check if we are running as the CVMFS repo owner, otherwise run cvmfs_server with sudo
 is_repo_owner || cvmfs_server="sudo cvmfs_server"


### PR DESCRIPTION
This PR addresses an issue when ingesting a tarball with an installation in a non-standard prefix coming from `dev.eessi.io`. This currently fails as spotted by @bedroge when merging https://github.com/EESSI/staging/pull/2176.
```
Stderr:

/opt/eessi/filesystem-layer/scripts/ingest-tarball.sh: line 273: ingest_example_tarball: command not found
```

The call to `ingest_${tar_contents_type_dir}_tarball()` should only point to `ingest_init_tarball()`, `ingest_scritps_tarball()`, `ingest_compat_tarball()` or `ingest_software_tarball()`. This fails, because when ingesting in `dev.eessi.io` `${tar_contents_type_dir}` will instead be `$EESSI_DEV_PROJECT` (as currently defined [here](https://github.com/EESSI/dev.eessi.io-scripts/blob/393224d7c329345fdea42b78d26546be0e7426ea/bot/bot-build-dev.eessi.io.slurm#L29C8-L29C25), to be changed to something not hard-coded soon.) Here I add a condition to look for the type of tarball to be ingested differently in `dev.eessi.io` builds.


