### PR TITLE
Add cvmfs_shrinkwrap to EESSI container to enable exporting EESSI environment

### DIFF
--- a/containers/Dockerfile.EESSI-client-rocky8
+++ b/containers/Dockerfile.EESSI-client-rocky8
@@ -29,6 +29,7 @@ RUN elversion="$(rpm -q --queryformat '%{RELEASE}' rpm | cut -d '.' -f 2)" \
   && yum install -y /root/rpmbuild/RPMS/$(uname -m)/cvmfs-${cvmfsversion}-1.${elversion}.$(uname -m).rpm \
                     /root/rpmbuild/RPMS/$(uname -m)/cvmfs-fuse3-${cvmfsversion}-1.${elversion}.$(uname -m).rpm \
                     /root/rpmbuild/RPMS/$(uname -m)/cvmfs-libs-${cvmfsversion}-1.${elversion}.$(uname -m).rpm \
+                    /root/rpmbuild/RPMS/$(uname -m)/cvmfs-shrinkwrap-${cvmfsversion}-1.${elversion}.$(uname -m).rpm \
                     http://ecsft.cern.ch/dist/cvmfs/cvmfs-config/cvmfs-config-default-latest.noarch.rpm
 RUN yum install -y https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi-latest.noarch.rpm
 

--- a/containers/Dockerfile.EESSI-client-rocky8
+++ b/containers/Dockerfile.EESSI-client-rocky8
@@ -24,7 +24,7 @@ ARG cvmfsversion
 COPY --from=prepare-rpm /root/rpmbuild/RPMS /root/rpmbuild/RPMS
 COPY --from=build-fuse-overlayfs /usr/local/bin/fuse-overlayfs /usr/local/bin/fuse-overlayfs
 
-RUN yum install -y sudo vim openssh-clients lsof strace
+RUN yum install -y sudo vim openssh-clients lsof strace squashfs-tools
 RUN elversion="$(rpm -q --queryformat '%{RELEASE}' rpm | cut -d '.' -f 2)" \
   && yum install -y /root/rpmbuild/RPMS/$(uname -m)/cvmfs-${cvmfsversion}-1.${elversion}.$(uname -m).rpm \
                     /root/rpmbuild/RPMS/$(uname -m)/cvmfs-fuse3-${cvmfsversion}-1.${elversion}.$(uname -m).rpm \

--- a/containers/build-or-download-cvmfs-debs.sh
+++ b/containers/build-or-download-cvmfs-debs.sh
@@ -73,6 +73,7 @@ else
     wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs_${cvmfsversion}~1+${os}_${arch}.deb
     wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs-fuse3_${cvmfsversion}~1+${os}_${arch}.deb
     wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs-libs_${cvmfsversion}~1+${os}_${arch}.deb
+    wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs-shrinkwrap_${cvmfsversion}~1+${os}_${arch}.deb
 fi
 
 cd /root/deb

--- a/containers/build-or-download-cvmfs-rpms.sh
+++ b/containers/build-or-download-cvmfs-rpms.sh
@@ -18,4 +18,5 @@ else
     wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs-${cvmfsversion}-1.${elversion}.${arch}.rpm
     wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs-fuse3-${cvmfsversion}-1.${elversion}.${arch}.rpm
     wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs-libs-${cvmfsversion}-1.${elversion}.${arch}.rpm
+    wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-${cvmfsversion}/cvmfs-shrinkwrap-${cvmfsversion}-1.${elversion}.${arch}.rpm
 fi


### PR DESCRIPTION
With this included, a user could:

- Start the EESSI container on a new target system
- Load the environment they want to export (source EESSI, load their required modules)
- Run a script (yet to be created) that would
  - Generate a spec file for `cvmfs_shrinkwrap` based on the current environment
  - Run `cvmfs_shrinkwrap` to export the environment
  - Run `mksquashfs` to create a squashfs from the export
  - Tidy up

The resulting squashfs could be loaded in _any_ container (with Linux and a supported shell). One could give a hint about how to enable `host_injections` with the export.