### PR TITLE
Add functionality for verifying tarball signatures to automated ingestion scripts

### DIFF
--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -135,7 +135,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install cvmfs
 
       - name: Download cvmfs-config-eessi package
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: linux_packages
 
@@ -174,7 +174,7 @@ jobs:
           dnf install -y cvmfs cvmfs-config-none
 
       - name: Download cvmfs-config-eessi package
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: linux_packages
 
@@ -215,7 +215,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install cvmfs
 
       - name: Download cvmfs-config-eessi package
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: linux_packages
 
@@ -288,7 +288,7 @@ jobs:
         run: |
           echo ::set-output name=version::${GITHUB_REF#refs/tags/}
 
-      - uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           path: ./build_artifacts
 
@@ -319,7 +319,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
-      - uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           path: ./build_artifacts
 

--- a/.github/workflows/build-test-release-client-packages.yml
+++ b/.github/workflows/build-test-release-client-packages.yml
@@ -64,7 +64,7 @@ jobs:
           fpm_opts: "--debug -n cvmfs-config-eessi-${{ steps.get_version.outputs.version }} -t tar -a all -s dir -C ./package --description 'CVMFS configuration package for EESSI.'"
 
       - name: Upload packages as build artifacts
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: linux_packages
           path: cvmfs-config-eessi*

--- a/scripts/automated_ingestion/automated_ingestion.cfg.example
+++ b/scripts/automated_ingestion/automated_ingestion.cfg.example
@@ -9,6 +9,12 @@ download_dir = /where/to/store/download/tarballs
 ingestion_script = /absolute/path/to/ingest-tarball.sh
 metadata_file_extension = .meta.txt
 
+[signatures]
+signatures_required = no
+signature_file_extension = .sig
+signature_verification_script = /absolute/path/to/sign_verify_file_ssh.sh
+allowed_signers_file = /path/to/allowed_signers
+
 [aws]
 staging_buckets = {
     "software.eessi.io-2023.06": "software.eessi.io",

--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -198,6 +198,8 @@ class EessiTarball:
             else:
                 return True
 
+        # If signatures are provided, we should always verify them, regardless of the signatures_required.
+        # In order to do so, we need the verification script and an allowed signers file.
         verify_script = self.config['signatures']['signature_verification_script']
         allowed_signers_file = self.config['signatures']['allowed_signers_file']
         if not os.path.exists(verify_script):

--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -24,12 +24,16 @@ class EessiTarball:
         self.config = config
         self.git_repo = git_staging_repo
         self.metadata_file = object_name + config['paths']['metadata_file_extension']
+        self.metadata_sig_file = self.metadata_file + config['signatures']['signature_file_extension']
         self.object = object_name
+        self.object_sig = object_name + config['signatures']['signature_file_extension']
         self.s3 = s3
         self.bucket = bucket
         self.cvmfs_repo = cvmfs_repo
         self.local_path = os.path.join(config['paths']['download_dir'], os.path.basename(object_name))
+        self.local_sig_path = self.local_path + config['signatures']['signature_file_extension']
         self.local_metadata_path = self.local_path + config['paths']['metadata_file_extension']
+        self.local_metadata_sig_path = self.local_metadata_path + config['signatures']['signature_file_extension']
         self.url = f'https://{bucket}.s3.amazonaws.com/{object_name}'
 
         self.states = {
@@ -48,22 +52,35 @@ class EessiTarball:
         """
         Download this tarball and its corresponding metadata file, if this hasn't been already done.
         """
-        if force or not os.path.exists(self.local_path):
-            try:
-                self.s3.download_file(self.bucket, self.object, self.local_path)
-            except:
-                logging.error(
-                    f'Failed to download tarball {self.object} from {self.bucket} to {self.local_path}.'
-                )
-                self.local_path = None
-        if force or not os.path.exists(self.local_metadata_path):
-            try:
-                self.s3.download_file(self.bucket, self.metadata_file, self.local_metadata_path)
-            except:
-                logging.error(
-                    f'Failed to download metadata file {self.metadata_file} from {self.bucket} to {self.local_metadata_path}.'
-                )
-                self.local_metadata_path = None
+        files = [
+            (self.object, self.local_path, self.object_sig, self.local_sig_path),
+            (self.metadata_file, self.local_metadata_path, self.metadata_sig_file, self.local_metadata_sig_path),
+        ]
+        for (object, local_file, sig_object, local_sig_file) in files:
+            if force or not os.path.exists(local_file):
+                try:
+                    self.s3.download_file(self.bucket, object, local_file)
+                    # Also try to download the corresponding signature file; they may be optional.
+                    try:
+                        self.s3.download_file(self.bucket, sig_object, local_sig_file)
+                    except:
+                        if config['signatures'].getboolean('signatures_required', True):
+                            logging.error(
+                                f'Failed to download signature file {sig_object} for {object} from {self.bucket} to {local_sig_file}.'
+                            )
+                        else:
+                            logging.warning(
+                                f'Failed to download signature file {sig_object} for {object} from {self.bucket} to {local_sig_file}.' +
+                                 'Ignoring this, because signatures are not required with the current configuration.'
+                            )
+                except:
+                    logging.error(
+                        f'Failed to download {object} from {self.bucket} to {local_file}.'
+                    )
+                    # If either the tarball itself or its metadata cannot be downloaded, set both to None
+                    # to make sure that this tarball is completely ignored/skipped.
+                    self.local_path = None
+                    self.local_metadata_path = None
 
     def find_state(self):
         """Find the state of this tarball by searching through the state directories in the git repository."""
@@ -156,6 +173,47 @@ class EessiTarball:
         handler = self.states[self.state]['handler']
         handler()
 
+    def verify_signatures(self):
+        """Verify the signatures of the downloaded tarball and metadata file using the corresponding signature files."""
+
+        sig_missing_msg = 'Signature file %s is missing.'
+        sig_missing = False
+        for sig_file in [self.local_sig_path, self.local_metadata_sig_path]:
+            if not os.path.exists(sig_file):
+                logging.warning(sig_missing_msg % sig_file)
+                sig_missing = True
+
+        if sig_missing:
+            # If signature files are missing, we return a failure,
+            # unless the configuration specifies that signatures are not required.
+            if self.config['signatures'].getboolean('signatures_required', True):
+                return False
+            else:
+                return True
+
+        verify_script = self.config['signatures']['signature_verification_script']
+        allowed_signers_file = self.config['signatures']['allowed_signers_file']
+        if not os.path.exists(verify_script):
+            logging.error(f'Unable to verify signatures, the specified signature verification script does not exist!')
+            return False
+
+        if not os.path.exists(allowed_signers_file):
+            logging.error(f'Unable to verify signatures, the specified allowed signers file does not exist!')
+            return False
+
+        for (file, sig_file) in [(self.local_path, self.local_sig_path), (self.local_metadata_path, self.local_metadata_sig_path)]:
+            verify_cmd = subprocess.run(
+                [verify_script, 'verify', file, allowed_signers_file, sig_file],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+            if verify_cmd.returncode == 0:
+                logging.debug(f'Signature for {file} successfully verified.')
+            else:
+                logging.error(f'Failed to verify signature for {file}.')
+                return False
+
+        return True
+
     def verify_checksum(self):
         """Verify the checksum of the downloaded tarball with the one in its metadata file."""
         local_sha256 = sha256sum(self.local_path)
@@ -171,6 +229,13 @@ class EessiTarball:
         #TODO: check if there is an open issue for this tarball, and if there is, skip it.
         logging.info(f'Tarball {self.object} is ready to be ingested.')
         self.download()
+        logging.info('Verifying its signature...')
+        if not self.verify_signatures():
+            logging.error('Signature of tarball (or its metadata file) could not be verified!')
+            # Open issue?
+            return
+        else:
+            logging.debug(f'Signatures of {self.object} and its metadata file successfully verified.')
         logging.info('Verifying its checksum...')
         if not self.verify_checksum():
             logging.error('Checksum of downloaded tarball does not match the one in its metadata file!')
@@ -221,6 +286,10 @@ class EessiTarball:
         if not self.local_path or not self.local_metadata_path:
             logging.warn('Skipping this tarball...')
             return
+
+        # Verify the signatures of the tarball and metadata file.
+        if not self.verify_signatures():
+            logging.warn('Signature verification of the tarball or its metadata failed, skipping this tarball...')
 
         contents = ''
         with open(self.local_metadata_path, 'r') as meta:

--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -203,7 +203,7 @@ class EessiTarball:
 
         for (file, sig_file) in [(self.local_path, self.local_sig_path), (self.local_metadata_path, self.local_metadata_sig_path)]:
             verify_cmd = subprocess.run(
-                [verify_script, 'verify', file, allowed_signers_file, sig_file],
+                [verify_script, '--verify', '--allowed-signers-file', allowed_signers_file, '--file', file, '--signature-file', sig_file],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
             if verify_cmd.returncode == 0:

--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -231,7 +231,7 @@ class EessiTarball:
         self.download()
         logging.info('Verifying its signature...')
         if not self.verify_signatures():
-            issue_msg = f'Failed to verify signatures for {self.object}'
+            issue_msg = f'Failed to verify signatures for `{self.object}`'
             logging.error(issue_msg)
             if not self.issue_exists(issue_msg, state='open'):
                 self.git_repo.create_issue(title=issue_msg, body=issue_msg)
@@ -241,7 +241,7 @@ class EessiTarball:
 
         logging.info('Verifying its checksum...')
         if not self.verify_checksum():
-            issue_msg = f'Failed to verify checksum for {self.object}'
+            issue_msg = f'Failed to verify checksum for `{self.object}`'
             logging.error(issue_msg)
             if not self.issue_exists(issue_msg, state='open'):
                 self.git_repo.create_issue(title=issue_msg, body=issue_msg)

--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -75,7 +75,7 @@ class EessiTarball:
                             f'Failed to download signature file {sig_object} for {object} from {self.bucket} to {local_sig_file}. ' +
                              'Ignoring this, because signatures are not required with the current configuration.'
                         )
-                # Npw we download the file itself.
+                # Now we download the file itself.
                 try:
                     self.s3.download_file(self.bucket, object, local_file)
                 except:

--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -231,18 +231,24 @@ class EessiTarball:
         self.download()
         logging.info('Verifying its signature...')
         if not self.verify_signatures():
-            logging.error('Signature of tarball (or its metadata file) could not be verified!')
-            # Open issue?
+            issue_msg = f'Failed to verify signatures for {self.object}'
+            logging.error(issue_msg)
+            if not self.issue_exists(issue_msg, state='open'):
+                self.git_repo.create_issue(title=issue_msg, body=issue_msg)
             return
         else:
             logging.debug(f'Signatures of {self.object} and its metadata file successfully verified.')
+
         logging.info('Verifying its checksum...')
         if not self.verify_checksum():
-            logging.error('Checksum of downloaded tarball does not match the one in its metadata file!')
-            # Open issue?
+            issue_msg = f'Failed to verify checksum for {self.object}'
+            logging.error(issue_msg)
+            if not self.issue_exists(issue_msg, state='open'):
+                self.git_repo.create_issue(title=issue_msg, body=issue_msg)
             return
         else:
             logging.debug(f'Checksum of {self.object} matches the one in its metadata file.')
+
         script = self.config['paths']['ingestion_script']
         sudo = ['sudo'] if self.config['cvmfs'].getboolean('ingest_as_root', True) else []
         logging.info(f'Running the ingestion script for {self.object}...')


### PR DESCRIPTION
Still testing it, but first tests look good. I'm running a separate instance/fork of the automated ingestion on the Stratum 0, configured to use a test bucket and non-existing target repo. This successfully picked up the tarball+metadata file and their signatures from the test bucket (uploaded by @trz42  in https://github.com/EESSI/software-layer/pull/968):
```
-rw-r--r--. 1 eessi eessi 124619768 Mar 20 16:12 eessi-2023.06-software-linux-aarch64-nvidia-grace-1741954310.tar.gz
-rw-r--r--. 1 eessi eessi       663 Mar 20 16:12 eessi-2023.06-software-linux-aarch64-nvidia-grace-1741954310.tar.gz.meta.txt
-rw-r--r--. 1 eessi eessi       878 Mar 20 16:12 eessi-2023.06-software-linux-aarch64-nvidia-grace-1741954310.tar.gz.meta.txt.sig
-rw-r--r--. 1 eessi eessi       878 Mar 20 16:12 eessi-2023.06-software-linux-aarch64-nvidia-grace-1741954310.tar.gz.sig
```

The log shows that the signatures were successfully verified:
```
2025-03-20 16:12:59,176 - DEBUG - Signature for /srv/tmp/tarballs/eessi-2023.06-software-linux-aarch64-nvidia-grace-1741954310.tar.gz successfully verified.
2025-03-20 16:12:59,186 - DEBUG - Signature for /srv/tmp/tarballs/eessi-2023.06-software-linux-aarch64-nvidia-grace-1741954310.tar.gz.meta.txt successfully verified.
```

We should do the same for a non-valid signature (and make sure they fail), and for tarballs without a signature file (this should succeed if `signatures_required = no`).