### PR TITLE
Handle tarballs with `dev.eessi.io` project subdir in name

### DIFF
--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -258,11 +258,14 @@ version=$(echo "${tar_file_basename}" | cut -d- -f2)
 contents_type_dir=$(echo "${tar_file_basename}" | cut -d- -f3)
 tar_first_file=$(tar tf "${tar_file}" | head -n 1)
 tar_top_level_dir=$(echo "${tar_first_file}" | cut -d/ -f1)
-# Handle longer prefix with project name in dev.eessi.io
+# Handle longer prefix with project name in dev.eessi.io and
+# get 
 if [ "${cvmfs_repo}" = "dev.eessi.io" ]; then
     tar_contents_start_level=3
+    basedir=$(echo "${tar_file_basename}" | cut -d- -f7)
 else
     tar_contents_start_level=2
+    basedir=versions
 fi
 tar_contents_type_dir=$(tar tf "${tar_file}" | head -n 2 | tail -n 1 | cut -d/ -f${tar_contents_start_level})
 


### PR DESCRIPTION
The software-layer PR for support for `dev.eessi.io builds encodes the subdir name in the tarball. Because the file tree has a different depth and the position of the project subdirectory in the tree moved, this also had to be adjusted. This PR handles these changes and _should_ not impact other builds for `software.eessi.io`.