### PR TITLE
abort transaction if Lmod cache update failed

### DIFF
--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -188,7 +188,7 @@ function update_lmod_caches() {
         ${cvmfs_server} publish -m "update Lmod caches after ingesting ${tar_file_basename}" "${cvmfs_repo}"
     else
         ${cvmfs_server} abort "${cvmfs_repo}"
-        error "Update of Lmod caches after ingesting ${tar_file_basename} for ${cvmfs_repo} failed\!"
+        error "Update of Lmod caches after ingesting ${tar_file_basename} for ${cvmfs_repo} failed!"
     fi
 }
 

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -181,7 +181,13 @@ function update_lmod_caches() {
     fi
     ${cvmfs_server} transaction "${cvmfs_repo}"
     ${update_caches_script} /cvmfs/${cvmfs_repo}/${basedir}/${version}
-    ${cvmfs_server} publish -m "update Lmod caches after ingesting ${tar_file_basename}" "${cvmfs_repo}"
+    ec=$?
+    if [ $ec -eq 0 ]; then
+        ${cvmfs_server} publish -m "update Lmod caches after ingesting ${tar_file_basename}" "${cvmfs_repo}"
+    else
+        ${cvmfs_server} abort "${cvmfs_repo}"
+        error "Update of Lmod caches after ingesting ${tar_file_basename} for ${cvmfs_repo} failed\!"
+    fi
 }
 
 function ingest_init_tarball() {

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -187,7 +187,7 @@ function update_lmod_caches() {
     if [ $ec -eq 0 ]; then
         ${cvmfs_server} publish -m "update Lmod caches after ingesting ${tar_file_basename}" "${cvmfs_repo}"
     else
-        ${cvmfs_server} abort "${cvmfs_repo}"
+        ${cvmfs_server} abort -f "${cvmfs_repo}"
         error "Update of Lmod caches after ingesting ${tar_file_basename} for ${cvmfs_repo} failed!"
     fi
 }

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -12,6 +12,8 @@
 
 # Only if it passes these checks, the tarball gets ingested to the base dir in the repository specified below.
 
+CVMFS_ROOT=${CUSTOM_CVMFS_ROOT:-/cvmfs}
+
 basedir=versions
 decompress="gunzip -c"
 cvmfs_server="cvmfs_server"
@@ -180,7 +182,7 @@ function update_lmod_caches() {
         error "the script for updating the Lmod caches (${update_caches_script}) does not have execute permissions!"
     fi
     ${cvmfs_server} transaction "${cvmfs_repo}"
-    ${update_caches_script} /cvmfs/${cvmfs_repo}/${basedir}/${version}
+    ${update_caches_script} "${CVMFS_ROOT}/${cvmfs_repo}/${basedir}/${version}"
     ec=$?
     if [ $ec -eq 0 ]; then
         ${cvmfs_server} publish -m "update Lmod caches after ingesting ${tar_file_basename}" "${cvmfs_repo}"
@@ -212,7 +214,7 @@ function ingest_compat_tarball() {
     # Handle the ingestion of tarballs containing a compatibility layer
     check_arch
     check_os
-    compat_layer_path="/cvmfs/${cvmfs_repo}/${basedir}/${version}/compat/${os}/${arch}"
+    compat_layer_path="${CVMFS_ROOT}/${cvmfs_repo}/${basedir}/${version}/compat/${os}/${arch}"
     # Assume that we already had a compat layer in place if there is a startprefix script in the corresponding CVMFS directory
     if [ -f "${compat_layer_path}/startprefix" ];
     then
@@ -223,7 +225,7 @@ function ingest_compat_tarball() {
         old_layer_suffixed_path="${compat_layer_path}-${new_suffix}"
         echo_yellow "Moving the existing compat layer from ${compat_layer_path} to ${old_layer_suffixed_path}..."
         mv ${compat_layer_path} ${old_layer_suffixed_path}
-        tar -C "/cvmfs/${cvmfs_repo}/${basedir}/" -xzf "${tar_file}"
+        tar -C "${CVMFS_ROOT}/${cvmfs_repo}/${basedir}/" -xzf "${tar_file}"
         ${cvmfs_server} publish -m "updated compat layer for ${version}, ${os}, ${arch}" "${cvmfs_repo}"
         ec=$?
         if [ $ec -eq 0 ]

--- a/scripts/test-ingest-tarball.sh
+++ b/scripts/test-ingest-tarball.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-INGEST_SCRIPT=$(dirname "$(realpath $0)")/ingest-tarball.sh
-TEST_OUTPUT=$(mktemp)
-
 # Temporary base dir for the tests
 tstdir=$(mktemp -d)
+
+# let ingest-tarball.sh script not use /cvmfs, but a temporary directory we can create
+export CUSTOM_CVMFS_ROOT=${tstdir}/cvmfs
+
+INGEST_SCRIPT=$(dirname "$(realpath $0)")/ingest-tarball.sh
+TEST_OUTPUT=${tstdir}/out.txt
 
 # Statistics
 num_tests=0
@@ -86,6 +89,16 @@ tarballs_fail=(
   "$tstdir/eessi-2000.01-compat-123456.tar.gz 2000.01 compat/linux/sparc"
   "$tstdir/eessi-2000.01-compat-123456.tar.gz 2000.01 compat"
 )
+
+# update_lmod_caches.sh script requires that directory exists,
+# and that script to update Lmod cache is found in there
+repo_version_root="${CUSTOM_CVMFS_ROOT}/my.repo.tld/versions/2000.01"
+lmod_libexec_path="${repo_version_root}/compat/linux/$(uname -m)/usr/share/Lmod/libexec/"
+mkdir -p "${lmod_libexec_path}"
+lmod_update_script="${lmod_libexec_path}/update_lmod_system_cache_files"
+touch "${lmod_update_script}"
+chmod u+x "${lmod_update_script}"
+
 
 # Run the tests that should succeed
 for ((i = 0; i < ${#tarballs_success[@]}; i++)); do

--- a/scripts/test-ingest-tarball.sh
+++ b/scripts/test-ingest-tarball.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 INGEST_SCRIPT=$(dirname "$(realpath $0)")/ingest-tarball.sh
-TEST_OUTPUT=/dev/null # change to /dev/stdout to print test outputs for debugging purposes
+TEST_OUTPUT=$(mktemp)
 
 # Temporary base dir for the tests
 tstdir=$(mktemp -d)
@@ -92,10 +92,15 @@ for ((i = 0; i < ${#tarballs_success[@]}; i++)); do
     t=$(create_tarball ${tarballs_success[$i]})
     "${INGEST_SCRIPT}" "my.repo.tld" "$t" >& "${TEST_OUTPUT}"
     if [ ! $? -eq 0 ]; then
+        echo ">> ${tarballs_success[$i]} test with existing repo FAILed!" >&2
+        echo ">> output:" >&2
+        cat "${TEST_OUTPUT}" >&2
+        echo >&2
         num_tests_failed=$((num_tests_failed + 1))
     else
         num_tests_succeeded=$((num_tests_succeeded + 1))
     fi
+    rm -f "${TEST_OUTPUT}"
     num_tests=$((num_tests + 1))
 done
 
@@ -104,10 +109,15 @@ for ((i = 0; i < ${#tarballs_fail[@]}; i++)); do
     t=$(create_tarball ${tarballs_fail[$i]})
     "${INGEST_SCRIPT}" "my.repo.tld" "$t" >& "${TEST_OUTPUT}"
     if [ ! $? -eq 1 ]; then
+        echo ">> ${tarballs_fail[$i]} test passed, but should have failed!" >&2
+        echo ">> output:" >&2
+        cat "${TEST_OUTPUT}" >&2
+        echo >&2
         num_tests_failed=$((num_tests_failed + 1))
     else
         num_tests_succeeded=$((num_tests_succeeded + 1))
     fi
+    rm -f "${TEST_OUTPUT}"
     num_tests=$((num_tests + 1))
 done
 
@@ -116,10 +126,15 @@ for ((i = 0; i < ${#tarballs_success[@]}; i++)); do
     t=$(create_tarball ${tarballs_success[$i]})
     "${INGEST_SCRIPT}" "my.nonexistingrepo.tld" "$t" >& "${TEST_OUTPUT}"
     if [ ! $? -eq 1 ]; then
+        echo ">> ${tarballs_success[$i]} test passed with non-existing repo, should have failed!" >&2
+        echo ">> output:" >&2
+        cat "${TEST_OUTPUT}" >&2
+        echo >&2
         num_tests_failed=$((num_tests_failed + 1))
     else
         num_tests_succeeded=$((num_tests_succeeded + 1))
     fi
+    rm -f "${TEST_OUTPUT}"
     num_tests=$((num_tests + 1))
 done
 


### PR DESCRIPTION
We're not checking the exit code after doing the Lmod cache update, we should.

Trigger for this is missing Lmod cache files currently for `intel/cascadelake` and `intel/icelake` CPU targets:
```
$ ls -lrtd /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/*/.lmod/cache
drwxr-xr-x 2 cvmfs cvmfs 117 May 28 23:36 /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/.lmod/cache
drwxr-xr-x 2 cvmfs cvmfs 117 May 28 23:36 /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/skylake_avx512/.lmod/cache
drwxr-xr-x 2 cvmfs cvmfs 117 May 28 23:36 /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/sapphirerapids/.lmod/cache
```

Note: this is totally untested!