### PR TITLE
build and install `bwrap` from source in Debian 11 build container

### DIFF
--- a/.github/workflows/test-containers.yml
+++ b/.github/workflows/test-containers.yml
@@ -12,3 +12,9 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Build the Docker image
         run: docker build . --file containers/Dockerfile.EESSI-client-rocky8
+  test-build-container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - name: Build the Docker image
+        run: docker build . --file containers/Dockerfile.EESSI-build-node-debian11

--- a/containers/Dockerfile.EESSI-build-node-debian11
+++ b/containers/Dockerfile.EESSI-build-node-debian11
@@ -1,6 +1,7 @@
 ARG cvmfsversion=2.13.0
 ARG awscliversion=1.32.22
 ARG fuseoverlayfsversion=1.10
+ARG bwrapversion=0.11.0
 
 FROM debian:11.7 AS prepare-deb
 ARG cvmfsversion
@@ -12,6 +13,7 @@ FROM debian:11.5
 ARG cvmfsversion
 ARG awscliversion
 ARG fuseoverlayfsversion
+ARG bwrapversion
 
 COPY --from=prepare-deb /root/deb /root/deb
 
@@ -39,3 +41,19 @@ RUN useradd -ms /bin/bash eessi
 
 # stick to awscli v1.x, 2.x is not available through PyPI (see https://github.com/aws/aws-cli/issues/4947)
 RUN pip3 install archspec awscli==${awscliversion}
+
+# build + install bwrap from source
+RUN apt-get install -y libcap-dev meson ninja-build pkg-config \
+  && curl -OL https://github.com/containers/bubblewrap/releases/download/v${bwrapversion}/bubblewrap-${bwrapversion}.tar.xz \
+  && tar xvf bubblewrap-${bwrapversion}.tar.xz \
+  && cd bubblewrap-${bwrapversion} \
+  && meson setup _build \
+  && meson compile -C _build \
+  && meson test -C _build \
+  && meson install -C _build \
+  && which bwrap \
+  && bwrap --version \
+  && bwrap --help \
+  && cd .. \
+  && rm -r bubblewrap-${bwrapversion} \
+  && apt-get remove -y libcap-dev meson ninja-build pkg-config


### PR DESCRIPTION
Latest version of `bwrap` (0.11.0) includes support for creating writable overlays, so perhaps we can move away from the dreaded `fuse-overlayfs` and use `bwrap` instead?

I would like to add `bwrap` to our build container, so I can experiment with this...