### PR TITLE
Only update Lmod cache for `software.eessi.io`

### DIFF
--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -207,7 +207,9 @@ function ingest_software_tarball() {
     check_arch
     check_os
     cvmfs_ingest_tarball
-    update_lmod_caches
+    if [ "${cvmfs_repo}" = "software.eessi.io" ]; then
+        update_lmod_caches
+    fi
 }
 
 function ingest_compat_tarball() {


### PR DESCRIPTION
This is a (temporary) fix for the dev.eessi.io tarballs: after https://github.com/EESSI/filesystem-layer/pull/219 got merged, the ingestion script is now failing, because the Lmod cache for the dev repo could not be created. This is mainly due to not having a compat layer in the same repo (where we try to find the actual cache update script shipped with Lmod). While I was trying to implement a fix for that, I realized we may first want to think about if/how we do the Lmod caches for the dev repo. We have the additional project subdirectory in there, and every project could have its own set of CPU targets. Also, we don't have Lmod RC files /modulefiles in there yet, so it's a bit tricky to make use of caches right now anyway.

The RISC-V repo currently does have a compat layer, and we could leave it enabled for that one. However, we will soon start building on top of a compat layer shipped in `software.eessi.io`, and then we run into a similar issue. Therefore, I'm disabling it for all repos except software.eessi.io.
