### PR TITLE
Skip unsigned tarballs

### DIFF
--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -307,6 +307,7 @@ class EessiTarball:
         # Verify the signatures of the tarball and metadata file.
         if not self.verify_signatures():
             logging.warn('Signature verification of the tarball or its metadata failed, skipping this tarball...')
+            return
 
         contents = ''
         with open(self.local_metadata_path, 'r') as meta:


### PR DESCRIPTION
Even though we enabled a setting to skip unsigned tarballs today, a staging PR just got opened for a tarball that was not signed (well, actually it was, but the key was not added to the allowed signers yet, so the ingestion script will assume it's not (properly) signed):
https://github.com/EESSI/staging/pull/3008

Looks like a return was missing...