### PR TITLE
Print directory names of reprod subdirs in staging PR's tarball overview

### DIFF
--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -145,15 +145,21 @@ class EessiTarball:
                 for m in members
                 if m.isfile() and PurePosixPath(m.path).match(os.path.join(prefix, 'modules', '*', '*', '*.lua'))
             ]
+            reprod_dirs = [
+                m.path
+                for m in members
+                if m.isdir() and PurePosixPath(m.path).match(os.path.join(prefix, 'reprod', '*', '*', '*'))
+            ]
             other = [  # anything that is not in <prefix>/software nor <prefix>/modules
                 m.path
                 for m in members
                 if not PurePosixPath(prefix).joinpath('software') in PurePosixPath(m.path).parents
                    and not PurePosixPath(prefix).joinpath('modules') in PurePosixPath(m.path).parents
+                   and not PurePosixPath(prefix).joinpath('reprod') in PurePosixPath(m.path).parents
                 # if not fnmatch.fnmatch(m.path, os.path.join(prefix, 'software', '*'))
                 # and not fnmatch.fnmatch(m.path, os.path.join(prefix, 'modules', '*'))
             ]
-            members_list = sorted(swdirs + modfiles + other)
+            members_list = sorted(swdirs + modfiles + reprod_dirs + other)
 
         # Construct the overview.
         tar_members = '\n'.join(members_list)

--- a/scripts/automated_ingestion/eessitarball.py
+++ b/scripts/automated_ingestion/eessitarball.py
@@ -150,7 +150,7 @@ class EessiTarball:
                 for m in members
                 if m.isdir() and PurePosixPath(m.path).match(os.path.join(prefix, 'reprod', '*', '*', '*'))
             ]
-            other = [  # anything that is not in <prefix>/software nor <prefix>/modules
+            other = [  # anything that is not in <prefix>/software nor <prefix>/modules nor <prefix>/reprod
                 m.path
                 for m in members
                 if not PurePosixPath(prefix).joinpath('software') in PurePosixPath(m.path).parents


### PR DESCRIPTION
It will just include the three levels deep directory names (and not their contents) under `reprod`, e.g.:
```
2025.06/software/linux/x86_64/intel/skylake_avx512/reprod/EasyBuild/5.1.1/20250718_190714UTC
```