### PR TITLE
Upgrade CVMFS version in client container

### DIFF
--- a/containers/Dockerfile.EESSI-client-rocky8
+++ b/containers/Dockerfile.EESSI-client-rocky8
@@ -1,4 +1,4 @@
-ARG cvmfsversion=2.13.0
+ARG cvmfsversion=2.13.3
 # Stick to old version of fuse-overlayfs due to issues with newer versions
 # (cfr. https://github.com/containers/fuse-overlayfs/issues/232)
 ARG fuseoverlayfsversion=1.10


### PR DESCRIPTION
I used this version to play around with CVMFS shrinkwrap yesterday, and did not see the issues that @casparvl saw in https://github.com/cvmfs/cvmfs/issues/3958 (RAM usage would rise and fall, never going above about 4GB)