### PR TITLE
add `host_injections` variant symlink to `dev.eessi.io`

### DIFF
--- a/roles/create_cvmfs_content_structure/vars/dev.eessi.io.yml
+++ b/roles/create_cvmfs_content_structure/vars/dev.eessi.io.yml
@@ -12,4 +12,6 @@ files: # noqa: var-naming[no-role-prefix]
     dest: 'README'
     mode: '644'
 
-symlinks: [] # noqa: var-naming[no-role-prefix]
+symlinks: # noqa: var-naming[no-role-prefix]
+  host_injections: '$(EESSI_DEV_HOST_INJECTIONS:-/cvmfs/software.eessi.io/host_injections)'
+

--- a/roles/create_cvmfs_content_structure/vars/dev.eessi.io.yml
+++ b/roles/create_cvmfs_content_structure/vars/dev.eessi.io.yml
@@ -14,4 +14,3 @@ files: # noqa: var-naming[no-role-prefix]
 
 symlinks: # noqa: var-naming[no-role-prefix]
   host_injections: '$(EESSI_DEV_HOST_INJECTIONS:-/cvmfs/software.eessi.io/host_injections)'
-


### PR DESCRIPTION
I ran into an issue when I was trying to use a site-specific SitePackage.lua for the `dev.eessi.io/riscv` repo, which didn't work because our scripts look for them in `$EESSI_PREFIX/host_injections` (see https://github.com/EESSI/software-layer-scripts/blob/main/create_lmodsitepackage.py#L41). For `dev.eessi.io` this location does not exist. This PR fixes that by adding a variant symlink `/cvmfs/dev.eessi.io/host_injections`, which by default simply points to `/cvmfs/software.eessi.io/host_injections`.