### PR TITLE
Generate Lmod caches for all repos, try harder to find an Lmod installation

### DIFF
--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -184,17 +184,46 @@ function update_lmod_caches() {
     then
         error "the script for updating the Lmod caches (${update_caches_script}) does not have execute permissions!"
     fi
-    ${cvmfs_server} transaction "${cvmfs_repo}"
-    # Find the oldest version that we have, and use its Lmod to generate the cache to get better backwards compatibilty with old Lmod versions
-    oldest_stack=$(ls -1 -v "${CVMFS_ROOT}/${cvmfs_repo}/${basedir}" | head -n 1)
-    oldest_stack_lmod_update_script="${CVMFS_ROOT}/${cvmfs_repo}/${basedir}/${oldest_stack}/compat/linux/$(uname -m)/usr/share/Lmod/libexec/update_lmod_system_cache_files"
-    ${update_caches_script} "${CVMFS_ROOT}/${cvmfs_repo}/${basedir}/${version}" "${oldest_stack_lmod_update_script}"
-    ec=$?
-    if [ $ec -eq 0 ]; then
-        ${cvmfs_server} publish -m "update Lmod caches after ingesting ${tar_file_basename}" "${cvmfs_repo}"
+
+    # Determine which Lmod installation to use for updating the caches:
+    #   - use $LMOD_LIBEXEC_DIR if set (and check if it indeed contains the required script, otherwise fail hard)
+    #   - if not set:
+    #     - look for a compatibility layer (which should have Lmod installed) in the current CVMFS repository
+    #     - otherwise, fall back to software.eessi.io, if available
+    #     - use the oldest compatibility layer in either repository to create the caches
+    #   - if no Lmod installation is found: give up and print a warning that the caches will not be created/updated
+    lmod_cvmfs_repo="${cvmfs_repo}"
+    lmod_update_system_cache_script=""
+    if [ ! -z "${LMOD_LIBEXEC_DIR}" ]; then
+        if [ -f "${LMOD_LIBEXEC_DIR}/update_lmod_system_cache_files" ]; then
+            lmod_update_system_cache_script="${LMOD_LIBEXEC_DIR}/update_lmod_system_cache_files"
+        else
+            error "No update_lmod_system_cache_files script found in the given \$LMOD_LIBEXEC_DIR ($LMOD_LIBEXEC_DIR)."
+        fi
     else
-        ${cvmfs_server} abort -f "${cvmfs_repo}"
-        error "Update of Lmod caches after ingesting ${tar_file_basename} for ${cvmfs_repo} failed!"
+        if [ ! -d "${CVMFS_ROOT}/${cvmfs_repo}/${basedir}/${version}/compat/linux/$(uname -m)/usr/share/Lmod" ]; then
+            if [ -d "${CVMFS_ROOT}/software.eessi.io/${basedir}" ]; then
+                lmod_cvmfs_repo="software.eessi.io"
+            else
+                print_yellow "Lmod cache update failed: cannot find a compatibility layer with an Lmod installation."
+            fi
+        fi
+        # Find the oldest version that we have, and use its Lmod to generate the cache to get better backwards compatibilty with old Lmod versions
+        oldest_stack=$(ls -1 -v "${CVMFS_ROOT}/${lmod_cvmfs_repo}/${basedir}" | head -n 1)
+        lmod_update_system_cache_script="${CVMFS_ROOT}/${lmod_cvmfs_repo}/${basedir}/${oldest_stack}/compat/linux/$(uname -m)/usr/share/Lmod/libexec/update_lmod_system_cache_files"
+    fi
+    if [ ! -f "${lmod_update_system_cache_script}" ]; then
+        print_yellow "Lmod cache update failed: cannot find an Lmod installation."
+    else
+        ${cvmfs_server} transaction "${cvmfs_repo}"
+        ${update_caches_script} "${CVMFS_ROOT}/${cvmfs_repo}/${basedir}/${version}" "${lmod_update_system_cache_script}"
+        ec=$?
+        if [ $ec -eq 0 ]; then
+            ${cvmfs_server} publish -m "update Lmod caches after ingesting ${tar_file_basename}" "${cvmfs_repo}"
+        else
+            ${cvmfs_server} abort -f "${cvmfs_repo}"
+            error "Update of Lmod caches after ingesting ${tar_file_basename} for ${cvmfs_repo} failed!"
+        fi
     fi
 }
 
@@ -213,9 +242,7 @@ function ingest_software_tarball() {
     check_arch
     check_os
     cvmfs_ingest_tarball
-    if [ "${cvmfs_repo}" = "software.eessi.io" ]; then
-        update_lmod_caches
-    fi
+    update_lmod_caches
 }
 
 function ingest_compat_tarball() {

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -184,6 +184,8 @@ function update_lmod_caches() {
     then
         error "the script for updating the Lmod caches (${update_caches_script}) does not have execute permissions!"
     fi
+    # if we are not the repo owner, the Lmod cache script needs to be run with sudo to prevent "Permission denied" errors
+    is_repo_owner ||  update_caches_script="sudo ${update_caches_script}"
 
     # Determine which Lmod installation to use for updating the caches:
     #   - use $LMOD_LIBEXEC_DIR if set (and check if it indeed contains the required script, otherwise fail hard)

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -205,7 +205,7 @@ function update_lmod_caches() {
             if [ -d "${CVMFS_ROOT}/software.eessi.io/${basedir}" ]; then
                 lmod_cvmfs_repo="software.eessi.io"
             else
-                print_yellow "Lmod cache update failed: cannot find a compatibility layer with an Lmod installation."
+                echo_yellow "Lmod cache update failed: cannot find a compatibility layer with an Lmod installation."
             fi
         fi
         # Find the oldest version that we have, and use its Lmod to generate the cache to get better backwards compatibilty with old Lmod versions
@@ -213,7 +213,7 @@ function update_lmod_caches() {
         lmod_update_system_cache_script="${CVMFS_ROOT}/${lmod_cvmfs_repo}/${basedir}/${oldest_stack}/compat/linux/$(uname -m)/usr/share/Lmod/libexec/update_lmod_system_cache_files"
     fi
     if [ ! -f "${lmod_update_system_cache_script}" ]; then
-        print_yellow "Lmod cache update failed: cannot find an Lmod installation."
+        echo_yellow "Lmod cache update failed: cannot find an Lmod installation."
     else
         ${cvmfs_server} transaction "${cvmfs_repo}"
         ${update_caches_script} "${CVMFS_ROOT}/${cvmfs_repo}/${basedir}/${version}" "${lmod_update_system_cache_script}"

--- a/scripts/ingest-tarball.sh
+++ b/scripts/ingest-tarball.sh
@@ -213,7 +213,7 @@ function update_lmod_caches() {
         lmod_update_system_cache_script="${CVMFS_ROOT}/${lmod_cvmfs_repo}/${basedir}/${oldest_stack}/compat/linux/$(uname -m)/usr/share/Lmod/libexec/update_lmod_system_cache_files"
     fi
     if [ ! -f "${lmod_update_system_cache_script}" ]; then
-        print_yellow "Lmod cache update failed: cannot find an Lmod installation."
+        print_yellow "Lmod cache update failed: cannot find the Lmod cache update script (${lmod_update_system_cache_script})."
     else
         ${cvmfs_server} transaction "${cvmfs_repo}"
         ${update_caches_script} "${CVMFS_ROOT}/${cvmfs_repo}/${basedir}/${version}" "${lmod_update_system_cache_script}"

--- a/scripts/test-ingest-tarball.sh
+++ b/scripts/test-ingest-tarball.sh
@@ -171,7 +171,6 @@ for ((i = 0; i < ${#tarballs_success[@]}; i++)); do
     num_tests=$((num_tests + 1))
 done
 
-
 # Clean up
 rm -rf "${tstdir}"
 

--- a/scripts/test-ingest-tarball.sh
+++ b/scripts/test-ingest-tarball.sh
@@ -108,22 +108,33 @@ lmod_update_script="${lmod_libexec_path}/update_lmod_system_cache_files"
 touch "${lmod_update_script}"
 chmod u+x "${lmod_update_script}"
 
-
 # Run the tests that should succeed
-for ((i = 0; i < ${#tarballs_success[@]}; i++)); do
-    t=$(create_tarball ${tarballs_success[$i]})
-    "${INGEST_SCRIPT}" "my.repo.tld" "$t" >& "${TEST_OUTPUT}"
-    if [ ! $? -eq 0 ]; then
-        echo ">> ${tarballs_success[$i]} test with existing repo FAILed!" >&2
-        echo ">> output:" >&2
-        cat "${TEST_OUTPUT}" >&2
-        echo >&2
-        num_tests_failed=$((num_tests_failed + 1))
-    else
-        num_tests_succeeded=$((num_tests_succeeded + 1))
+for ((lmod_envs = 0; lmod_envs < 3; lmod_envs++)); do
+    if [ $lmod_envs -eq 1 ]; then
+        mkdir -p "${CUSTOM_CVMFS_ROOT}/software.eessi.io/versions/2000.01/"
+        mv "${repo_version_root}/compat" "${CUSTOM_CVMFS_ROOT}/software.eessi.io/versions/2000.01/compat"
     fi
-    rm -f "${TEST_OUTPUT}"
-    num_tests=$((num_tests + 1))
+    if [ $lmod_envs -eq 2 ]; then
+        mkdir "${tstdir}/lmod"
+        mv "${CUSTOM_CVMFS_ROOT}/software.eessi.io/versions/2000.01/compat/linux/$(uname -m)/usr/share/Lmod/libexec/update_lmod_system_cache_files" "${tstdir}/lmod"
+        rm -rf "{CUSTOM_CVMFS_ROOT}/software.eessi.io/versions/2000.01/compat/"
+        export LMOD_LIBEXEC_DIR="${tstdir}/lmod"
+    fi
+    for ((i = 0; i < ${#tarballs_success[@]}; i++)); do
+        t=$(create_tarball ${tarballs_success[$i]})
+        "${INGEST_SCRIPT}" "my.repo.tld" "$t" >& "${TEST_OUTPUT}"
+        if [ ! $? -eq 0 ]; then
+            echo ">> ${tarballs_success[$i]} test with existing repo FAILed!" >&2
+            echo ">> output:" >&2
+            cat "${TEST_OUTPUT}" >&2
+            echo >&2
+            num_tests_failed=$((num_tests_failed + 1))
+        else
+            num_tests_succeeded=$((num_tests_succeeded + 1))
+        fi
+        rm -f "${TEST_OUTPUT}"
+        num_tests=$((num_tests + 1))
+    done
 done
 
 # Run the tests that should fail
@@ -159,6 +170,7 @@ for ((i = 0; i < ${#tarballs_success[@]}; i++)); do
     rm -f "${TEST_OUTPUT}"
     num_tests=$((num_tests + 1))
 done
+
 
 # Clean up
 rm -rf "${tstdir}"


### PR DESCRIPTION
See the comment in the code for a description of how it tries to find an Lmod installation. The default for the production repo hasn't changed: it will still use the Lmod of the oldest EESSI version that we have. For other repos it will try to find Lmod in the current repo and otherwise it tries to fall back to software.eessi.io. Everything can be overridden by setting `$LMOD_LIBEXEC_DIR`.

Since this should now work for any repo that builds on top of EESSI, I've removed the condition that would only call the Lmod cache update for software.eessi.io, i.e. it will now do this unconditionally.

Also added tests for the different options.