### PR TITLE
add variant symlink for `$EPREFIX/var/lib/sss`

### DIFF
--- a/roles/create_cvmfs_content_structure/vars/software.eessi.io.yml
+++ b/roles/create_cvmfs_content_structure/vars/software.eessi.io.yml
@@ -72,6 +72,7 @@ symlinks: # noqa: var-naming[no-role-prefix]
   defaults/compat/etc/shadow: '$(EESSI_COMPAT_ETC_SHADOW:-/etc/shadow)'
   defaults/compat/usr/sbin/sendmail: '$(EESSI_COMPAT_SENDMAIL:-/usr/sbin/sendmail)'
   defaults/compat/var/db/passwd.db: '$(EESSI_COMPAT_VAR_DB_PASSWD_DB:-/var/db/passwd.db)'
+  defaults/compat/var/lib/sss: '$(EESSI_COMPAT_VAR_LIB_SSS:-/var/lib/sss)'
   defaults/compat/var/log/lastlog: '$(EESSI_COMPAT_VAR_LOG_LASTLOG:-/var/log/lastlog)'
   defaults/compat/var/log/wtmp: '$(EESSI_COMPAT_VAR_LOG_WTMP:-/var/log/wtmp)'
   defaults/compat/var/mail: '$(EESSI_COMPAT_VAR_MAIL:-/var/mail)'

--- a/roles/create_cvmfs_content_structure/vars/software.eessi.io.yml
+++ b/roles/create_cvmfs_content_structure/vars/software.eessi.io.yml
@@ -17,6 +17,9 @@ directories: # noqa: var-naming[no-role-prefix]
   - name: defaults/compat/var/db
     mode: '755'
 
+  - name: defaults/compat/var/lib
+    mode: '755'
+
   - name: defaults/compat/var/log
     mode: '755'
 


### PR DESCRIPTION
Follow-up for #270. Just realized that I forgot this one, since we deprefixified the paths in https://github.com/EESSI/gentoo-overlay/blob/main/sys-auth/sssd/sssd-2.13.0.ebuild#L210.