### PR TITLE
handle tarballs with different software prefixes

### DIFF
--- a/scripts/automated_ingestion/eessi_task_payload.py
+++ b/scripts/automated_ingestion/eessi_task_payload.py
@@ -62,46 +62,35 @@ class EESSITaskPayload:
 
         else:
             tar_members_desc = "Summarized overview of the contents of the tarball:"
-            # determine prefix after filtering out '<EESSI version>/init' subdirectory,
-            # to get actual prefix for specific CPU target (like '2023.06/software/linux/aarch64/neoverse_v1')
-            init_subdir = os.path.join("*", "init")
-            non_init_paths = sorted(
-                [path for path in paths if not any(parent.match(init_subdir) for parent in PurePosixPath(path).parents)]
-            )
-            if non_init_paths:
-                prefix = os.path.commonprefix(non_init_paths)
-            else:
-                prefix = os.path.commonprefix(paths)
 
             # TODO: this only works for software tarballs, how to handle compat layer tarballs?
             swdirs = [  # all directory names with the pattern: <prefix>/software/<name>/<version>
                 member.path
                 for member in members
-                if member.isdir() and PurePosixPath(member.path).match(os.path.join(prefix, 'software', '*', '*'))
+                if member.isdir() and PurePosixPath(member.path).match(os.path.join('**', 'software', '*', '*'))
             ]
             modfiles = [  # all filenames with the pattern: <prefix>/modules/<category>/<name>/*.lua
                 member.path
                 for member in members
                 if member.isfile()
-                and PurePosixPath(member.path).match(os.path.join(prefix, 'modules', '*', '*', '*.lua'))
+                and PurePosixPath(member.path).match(os.path.join('**', 'modules', '*', '*', '*.lua'))
             ]
-            reprod_dirs = [
+            reprod_dirs = [ # reprod dirs with the pattern: <prefix>/reprod/<name>/<version>/<timestamp>
                 member.path
                 for member in members
-                if member.isdir() and PurePosixPath(member.path).match(os.path.join(prefix, 'reprod', '*', '*', '*'))
+                if member.isdir() and PurePosixPath(member.path).match(os.path.join('**', 'reprod', '*', '*', '*'))
             ]
-            other = [  # anything that is not in <prefix>/software nor <prefix>/modules nor <prefix>/reprod
+            other = [  # anything that does not have software, modules, nor reprod in its path
                 member.path
                 for member in members
                 if (
-                    not PurePosixPath(prefix).joinpath('software') in PurePosixPath(member.path).parents
-                    and not PurePosixPath(prefix).joinpath('modules') in PurePosixPath(member.path).parents
-                    and not PurePosixPath(prefix).joinpath('reprod') in PurePosixPath(member.path).parents
+                    not PurePosixPath(member.path).full_match(os.path.join('**', 'software', '**'))
+                    and not PurePosixPath(member.path).full_match(os.path.join('**', 'modules', '**'))
+                    and not PurePosixPath(member.path).full_match(os.path.join('**', 'reprod', '**'))
                 )
-                # if not fnmatch.fnmatch(m.path, os.path.join(prefix, 'software', '*'))
-                # and not fnmatch.fnmatch(m.path, os.path.join(prefix, 'modules', '*'))
             ]
-            members_list = sorted(swdirs + modfiles + reprod_dirs + other)
+            # remove duplicates by converting to a set, and then sort
+            members_list = sorted(set(swdirs + modfiles + reprod_dirs + other))
 
         # construct the overview
         overview = config["github"]["task_summary_payload_overview_template"].format(

--- a/scripts/automated_ingestion/eessi_task_payload.py
+++ b/scripts/automated_ingestion/eessi_task_payload.py
@@ -75,7 +75,7 @@ class EESSITaskPayload:
                 if member.isfile()
                 and PurePosixPath(member.path).match(os.path.join('**', 'modules', '*', '*', '*.lua'))
             ]
-            reprod_dirs = [ # reprod dirs with the pattern: <prefix>/reprod/<name>/<version>/<timestamp>
+            reprod_dirs = [  # reprod dirs with the pattern: <prefix>/reprod/<name>/<version>/<timestamp>
                 member.path
                 for member in members
                 if member.isdir() and PurePosixPath(member.path).match(os.path.join('**', 'reprod', '*', '*', '*'))

--- a/scripts/automated_ingestion/eessi_task_payload.py
+++ b/scripts/automated_ingestion/eessi_task_payload.py
@@ -84,9 +84,12 @@ class EESSITaskPayload:
                 member.path
                 for member in members
                 if (
-                    not PurePosixPath(member.path).full_match(os.path.join('**', 'software', '**'))
-                    and not PurePosixPath(member.path).full_match(os.path.join('**', 'modules', '**'))
-                    and not PurePosixPath(member.path).full_match(os.path.join('**', 'reprod', '**'))
+                    # full_match functionality is only available since Python 3.13
+                    # not PurePosixPath(member.path).full_match(os.path.join('**', 'software', '**'))
+                    # and not PurePosixPath(member.path).full_match(os.path.join('**', 'modules', '**'))
+                    # and not PurePosixPath(member.path).full_match(os.path.join('**', 'reprod', '**'))
+                    # for now, simply find any files installed outside the <version>/software subtree
+                    PurePosixPath(member.path).parts[1] != 'software'
                 )
             ]
             # remove duplicates by converting to a set, and then sort

--- a/scripts/automated_ingestion/eessi_task_payload.py
+++ b/scripts/automated_ingestion/eessi_task_payload.py
@@ -104,7 +104,7 @@ class EESSITaskPayload:
                     continue
                 # skip already found module files
                 elif member.path in modfiles:
-                   continue
+                    continue
 
                 other.append(member.path)
 

--- a/scripts/automated_ingestion/eessi_task_payload.py
+++ b/scripts/automated_ingestion/eessi_task_payload.py
@@ -80,18 +80,32 @@ class EESSITaskPayload:
                 for member in members
                 if member.isdir() and PurePosixPath(member.path).match(os.path.join('**', 'reprod', '*', '*', '*'))
             ]
-            other = [  # anything that does not have software, modules, nor reprod in its path
-                member.path
-                for member in members
-                if (
-                    # full_match functionality is only available since Python 3.13
-                    # not PurePosixPath(member.path).full_match(os.path.join('**', 'software', '**'))
-                    # and not PurePosixPath(member.path).full_match(os.path.join('**', 'modules', '**'))
-                    # and not PurePosixPath(member.path).full_match(os.path.join('**', 'reprod', '**'))
-                    # for now, simply find any files installed outside the <version>/software subtree
-                    PurePosixPath(member.path).parts[1] != 'software'
-                )
-            ]
+            # the following may detect other files, but full_match functionality requires Python 3.13 or newer
+            # other = [  # anything that does not have software, modules, nor reprod in its path
+            #     member.path
+            #     for member in members
+            #     if (
+            #           not PurePosixPath(member.path).full_match(os.path.join('**', 'software', '**'))
+            #           and not PurePosixPath(member.path).full_match(os.path.join('**', 'modules', '**'))
+            #           and not PurePosixPath(member.path).full_match(os.path.join('**', 'reprod', '**'))
+            #     )
+            # ]
+
+            # more basic approach to find any other files/directories included in the tarball
+            other = []
+            for member in members:
+                # skip anything that is part of a software installation, i.e. relative to any of the found software directories
+                if any([PurePosixPath(member.path).is_relative_to(sw_dir) for sw_dir in swdirs]):
+                    continue
+                # skip anything that is in a found reprod directory or which is a parent directory of a reprod directory
+                elif any([PurePosixPath(member.path).is_relative_to(reprod_dir) or PurePosixPath(reprod_dir).parent.match(member.path) for reprod_dir in reprod_dirs]):
+                    continue
+                # skip already found module files
+                elif member.path in modfiles:
+                   continue
+
+                other.append(member.path)
+
             # remove duplicates by converting to a set, and then sort
             members_list = sorted(set(swdirs + modfiles + reprod_dirs + other))
 

--- a/scripts/automated_ingestion/eessi_task_payload.py
+++ b/scripts/automated_ingestion/eessi_task_payload.py
@@ -94,11 +94,13 @@ class EESSITaskPayload:
             # more basic approach to find any other files/directories included in the tarball
             other = []
             for member in members:
-                # skip anything that is part of a software installation, i.e. relative to any of the found software directories
+                # skip files/dirs that are inside software directories
                 if any([PurePosixPath(member.path).is_relative_to(sw_dir) for sw_dir in swdirs]):
                     continue
-                # skip anything that is in a found reprod directory or which is a parent directory of a reprod directory
-                elif any([PurePosixPath(member.path).is_relative_to(reprod_dir) or PurePosixPath(reprod_dir).parent.match(member.path) for reprod_dir in reprod_dirs]):
+                # skip files/dirs that are in a reprod directory or which is a parent directory of a reprod directory
+                elif any([PurePosixPath(member.path).is_relative_to(reprod_dir) or
+                          PurePosixPath(reprod_dir).parent.match(member.path)
+                          for reprod_dir in reprod_dirs]):
                     continue
                 # skip already found module files
                 elif member.path in modfiles:


### PR DESCRIPTION
This should solve the issues that we see for software tarballs with different CUDA compute capabilities, where it's currently trying to list all files in the tarball. See e.g. https://github.com/EESSI/staging_bundles/pull/642. This leads to issues with exceeding the maximum length of the messages.

Sort of tested this by manually running this particular piece of code on such a tarball, but will try to do a real test using the test stratum 0.

----------

Edit Caspar: 

I'll describe the fix here in more detail for posterity. The issue is that the `prefix` didn't match, since that would be the combination of one CPU arch + all GPU archs. The result is that all individual files in the tarball then get seen as 'other', meaning that all get listed individually (way too much). E.g. it would list a file like `2025.06/software/linux/x86_64/intel/haswell/accel/amd/gfx1030/reprod/HIP/6.4.1-rocm-compilers-19.0.0-ROCm-6.4.1/20260721_201107UTC/easybuild/HIP-6.3.3_correct_paths_clang_and_rocm_agent_enum.patch` in https://github.com/EESSI/staging_bundles/pull/645 .

The solution to that is to match any prefix - as long as it matches a software/module/reprod dir pattern. This causes it to recognize files belonging to the e.g. the reprod dir, and then only report the reprod dir (not each and every file in it). E.g. only `2025.06/software/linux/x86_64/intel/haswell/accel/amd/gfx1030/reprod/HIP/6.4.1-rocm-compilers-19.0.0-ROCm-6.4.1/20260721_201107UTC` for HIP for the gfx1030 target in https://github.com/EESSI/staging_bundles_test/pull/1 .

----------